### PR TITLE
Chore: refactor routes

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -10,18 +10,19 @@ import {
 import { AppLayout } from '~/layouts/AppLayout'
 import { routes } from '~constants/routes'
 import { AdminAuthProvider } from '~features/auth/context/AdminProtectedContext'
-import { LandingPage } from '~features/landing/LandingPage'
 
 import { adminRoutes, publicRoutes } from './routes'
 
 const router = createBrowserRouter([
   {
+    path: routes.index,
     element: <AppLayout />,
     children: [
+      //Public Route
       {
-        path: routes.index,
-        element: <LandingPage />,
+        children: publicRoutes,
       },
+      //Admin Route
       {
         path: routes.admin.index,
         element: (
@@ -30,10 +31,6 @@ const router = createBrowserRouter([
           </AdminAuthProvider>
         ),
         children: adminRoutes,
-      },
-      {
-        path: routes.public.index,
-        children: publicRoutes,
       },
       {
         path: '*',

--- a/frontend/src/app/routes/public.routes.tsx
+++ b/frontend/src/app/routes/public.routes.tsx
@@ -2,13 +2,14 @@ import { Navigate, RouteObject } from 'react-router-dom'
 
 import { PublicLayout } from '~/layouts/PublicLayout'
 import { routes } from '~constants/routes'
+import { LandingPage } from '~features/landing/LandingPage'
 import { ErrorPage } from '~features/public/ErrorPage'
 import { LetterPublicPage } from '~features/public/LetterPublicPage'
 
 export const publicRoutes: RouteObject[] = [
   {
     index: true,
-    element: <Navigate to={routes.public.letters} />,
+    element: <LandingPage />,
   },
   {
     path: `${routes.public.letters}/:letterPublicId`,

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -1,7 +1,6 @@
 export const routes = {
   index: '/',
   public: {
-    index: 'public',
     letters: 'letters',
     error: 'error',
   },

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -16,7 +16,7 @@ export const LetterPublicPage = (): JSX.Element => {
   })
 
   if (!isLetterLoading && !letter) {
-    return <Navigate to={`/${routes.public.index}/${routes.public.error}`} />
+    return <Navigate to={`/${routes.public.error}`} />
   }
   return (
     <VStack alignItems="left" spacing="0px">


### PR DESCRIPTION
## Context

_Why does this PR exist? What problem are you trying to solve? What issue does this close?_

Closes [this](https://www.notion.so/opengov/Refactor-public-frontend-routes-c4b0bd8a6cb74757a39f7da311a2cae7?pvs=4)

## Approach

_How did you solve the problem?_

Default `/` will now be the public view instead of `public`

**Features**:

- Refactored the structure of routes 

## Before & After Screenshots

**AFTER**:

Landing Page:
<img width="1821" alt="Screen Shot 2023-05-11 at 5 04 33 PM" src="https://github.com/opengovsg/letters/assets/56868622/f9204aa4-9f56-4d78-b32d-d29a8bc82e21">

Public Letters View:
<img width="1316" alt="Screen Shot 2023-05-11 at 5 05 57 PM" src="https://github.com/opengovsg/letters/assets/56868622/48b14426-7a35-40e9-850d-e0c21150a55c">


