### PR TITLE
build: add postman api key to ecs task definition

### DIFF
--- a/ecs-task-definition.json
+++ b/ecs-task-definition.json
@@ -59,6 +59,10 @@
         {
           "name": "DD_TAGS",
           "valueFrom": "letters-<ENV>-dd-tags"
+        },
+        {
+          "name": "POSTMANGOVSG_API_KEY",
+          "valueFrom": "letters-<ENV>-postman-api-key"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
## Problem

OTP logins on [prod](https://letters.beta.gov.sg) currently don't work, because the env variable for Postman API key is not defined

## Approach

Add the env variable for the Postman API key to the ECS task definition.

After this change, add `letters-<stg/prod>-postman-api-key` to the parameter store and ECS instances will be able to read it as the env var `POSTMANGOVSG_API_KEY`

## Deploy Notes

- [ ] Add `letters-<stg/prod>-postman-api-key` to param store
