### PR TITLE
fix: change class validation

### DIFF
--- a/shared/src/dtos/create-template.dto.ts
+++ b/shared/src/dtos/create-template.dto.ts
@@ -1,8 +1,8 @@
-import { IsDefined, IsString } from 'class-validator'
+import { IsArray, IsDefined, IsString } from 'class-validator'
 
 export class CreateTemplateDto {
   @IsDefined()
-  @IsString()
+  @IsArray()
   fields: string[]
   @IsDefined()
   @IsString()

--- a/shared/src/dtos/templates.dto.ts
+++ b/shared/src/dtos/templates.dto.ts
@@ -25,4 +25,4 @@ export class GetTemplateDto {
   updatedAt: string
 }
 
-export class UpdateTemplateDto { }
+export class UpdateTemplateDto {}

--- a/shared/src/dtos/templates.dto.ts
+++ b/shared/src/dtos/templates.dto.ts
@@ -1,8 +1,8 @@
-import { IsDefined, IsString } from 'class-validator'
+import { IsArray, IsDefined, IsString } from 'class-validator'
 
 export class CreateTemplateDto {
   @IsDefined()
-  @IsString()
+  @IsArray()
   fields: string[]
   @IsDefined()
   @IsString()
@@ -25,4 +25,4 @@ export class GetTemplateDto {
   updatedAt: string
 }
 
-export class UpdateTemplateDto {}
+export class UpdateTemplateDto { }


### PR DESCRIPTION
## Context

Currently requests made to creation of template have to use arrays in a weird way (storing the actual array as a string). Ideally we want to use the native array type for this instead of storing it as a literal string

_How did you solve the problem?_

Change the class-validation


## Before & After Screenshots

**BEFORE**:
Before change
<img width="340" alt="Screen Shot 2023-05-15 at 11 08 16 AM" src="https://github.com/opengovsg/letters/assets/56868622/7c469359-8076-4c9f-96b7-ef2229c33557">


**AFTER**:
After change
<img width="303" alt="Screen Shot 2023-05-15 at 11 08 44 AM" src="https://github.com/opengovsg/letters/assets/56868622/2d90e3bf-9d6e-4783-9fc7-e4949149cc29">

