### PR TITLE
fix: remove padding around rendered letter

### DIFF
--- a/frontend/src/features/tinymce/components/Editor.tsx
+++ b/frontend/src/features/tinymce/components/Editor.tsx
@@ -23,13 +23,13 @@ export const Editor = ({
   // tinymce not enabled
   if (!tinymceApiKey) {
     return (
-      <Box border="1px" borderColor="grey.200" p={8} bg="white">
+      <Box border="1px" borderColor="grey.200" bg="white">
         <div dangerouslySetInnerHTML={{ __html: html }}></div>
       </Box>
     )
   }
   return (
-    <Box border="1px" borderColor="grey.200" p={8} bg="white">
+    <Box border="1px" borderColor="grey.200" bg="white">
       <TinymceEditor
         apiKey={tinymceApiKey}
         initialValue={html}


### PR DESCRIPTION
## Context
Removes whitespace padding around rendered letter

**Before**
<img width="612" alt="Screenshot 2023-05-16 at 4 13 50 PM" src="https://github.com/opengovsg/letters/assets/39231249/bc97e613-3fb5-4720-a9cd-e0ea42d6c2ac">

**After**
<img width="577" alt="Screenshot 2023-05-16 at 4 13 33 PM" src="https://github.com/opengovsg/letters/assets/39231249/bc8d12c4-e1fa-4c6d-8519-7b66bb620243">
