### PR TITLE
chore: introduce placeholder empty value on convict parser for env va…

### DIFF
--- a/backend/src/config/config.service.ts
+++ b/backend/src/config/config.service.ts
@@ -5,9 +5,9 @@ import { CONFIG_ACCESSIBLE_BY_FRONTEND } from '~shared/constants/config'
 
 import { ConfigSchema, schema } from './config.schema'
 
-// AWS param store does not support empty values, so we use a string placeholder of `'undefined'`
-// If param store value is defined as `'undefined'`, we treat it as undefined and return the default value
-const PLACEHOLDER_UNDEFINED = 'undefined'
+// AWS param store does not support empty values, so we use a string placeholder of `'VALUE_NOT_SET'`
+// If param store value is defined as `'VALUE_NOT_SET'`, we treat it as undefined and return the default value
+const PLACEHOLDER_UNDEFINED = 'VALUE_NOT_SET'
 
 @Injectable()
 export class ConfigService {

--- a/backend/src/config/config.service.ts
+++ b/backend/src/config/config.service.ts
@@ -5,6 +5,10 @@ import { CONFIG_ACCESSIBLE_BY_FRONTEND } from '~shared/constants/config'
 
 import { ConfigSchema, schema } from './config.schema'
 
+// AWS param store does not support empty values, so we use a string placeholder of `'undefined'`
+// If param store value is defined as `'undefined'`, we treat it as undefined and return the default value
+const PLACEHOLDER_UNDEFINED = 'undefined'
+
 @Injectable()
 export class ConfigService {
   config: Config<ConfigSchema>
@@ -17,6 +21,9 @@ export class ConfigService {
   // We want to implicitly use the return type of convict get method.
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   get<K extends Path<ConfigSchema>>(key: K) {
+    if (this.config.get(key) === PLACEHOLDER_UNDEFINED) {
+      return this.config.default(key)
+    }
     return this.config.get(key)
   }
 


### PR DESCRIPTION
## Context

This PR introduces a placeholder string value `VALUE_NOT_SET` for our params that we treat as undefined. Going forward, if we set a value on the param store as `VALUE_NOT_SET`, then it is effectively treated as undefined and will default to the environment variable default set in our config schema.

## Details

The lifecycle of an environment variable in our application is as follows:
`Set in AWS Param Store → Injected into container at build via ECS task definition → Consumed by application code and validated by npm convict`

However, there are some situations in which we want the option to use the default environment variables, without doing additional set up. However, AWS Param Store does not allow us to define empty values. Therefore there are two possibilities that result:

- we need to have the values defined in Param Store, or
- we need to remove the key from ECS task definition (otherwise the ECS build fails)
 
The way we set up our ECS task definition also means that the environment variable needs to be set for either all the environments or none of them. 

This change allows us to use the placeholder string `VALUE_NOT_SET`  in the Param Store, which is treated as undefined in the application code and lets it default to the value set in the config schema.


## Tests
- Tested on staging with `letters-stg-tinymce-api-key` set to `VALUE_NOT_SET` and verified that the renderer defaults to plain HTML instead of the TinyMCE editor