### PR TITLE
chore: add otp secret to ecs-task-definition

### DIFF
--- a/ecs-task-definition.json
+++ b/ecs-task-definition.json
@@ -49,6 +49,10 @@
           "valueFrom": "letters-<ENV>-session-secret"
         },
         {
+          "name": "OTP_SECRET",
+          "valueFrom": "letters-<ENV>-otp-secret"
+        },
+        {
           "name": "DD_API_KEY",
           "valueFrom": "letters-<ENV>-dd-api-key"
         },


### PR DESCRIPTION
## Context

- Add otp secret to `ecs-task-definition.json`