### PR TITLE
chore: fix max bulk creation numbers

### DIFF
--- a/shared/src/constants/letters.ts
+++ b/shared/src/constants/letters.ts
@@ -1,1 +1,1 @@
-export const BULK_MAX_ROW_LENGTH = 10
+export const BULK_MAX_ROW_LENGTH = 500


### PR DESCRIPTION
## Context 
Increase `BULK_MAX_ROW_LENGTH` from 10 to 500