### PR TITLE
fix: error message more user friendly when the otp call to postman fails

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -36,10 +36,9 @@ export class AuthController {
       res.status(HttpStatus.OK).json({ message: 'OTP sent' })
     } catch (error) {
       this.logger.error(error)
-      res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
-        message:
-          'We could not send your OTP to this email address. Please try again later or contact us if the problem persists.',
-      })
+      res
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .json({ message: 'Error mailing OTP, please try again later.' })
     }
   }
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -36,9 +36,10 @@ export class AuthController {
       res.status(HttpStatus.OK).json({ message: 'OTP sent' })
     } catch (error) {
       this.logger.error(error)
-      res
-        .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .json({ message: (error as Record<string, string>).message })
+      res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+        message:
+          'We could not send your OTP to this email address. Please try again later or contact us if the problem persists.',
+      })
     }
   }
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   Res,
   Session,
 } from '@nestjs/common'
+import { AxiosError } from '@nestjs/terminus/dist/errors/axios.error'
 import { Request, Response } from 'express'
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
 
@@ -37,7 +38,9 @@ export class AuthController {
     } catch (error) {
       this.logger.error(error)
       res
-        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .status(
+          ((error as AxiosError).response as Record<string, number>).status,
+        )
         .json({ message: 'Error mailing OTP, please try again later.' })
     }
   }


### PR DESCRIPTION
Provide a more helpful error message to the user in case the call to postman fails.
Reusing the error message from go.gov.sg


**Before:**
<img width="722" alt="Screenshot 2023-05-22 at 6 20 45 PM" src="https://github.com/opengovsg/letters/assets/12240377/cc5e05b1-6a11-46a2-a6ad-4541a072f3d0">


**After:**
<img width="728" alt="Screenshot 2023-05-22 at 6 40 56 PM" src="https://github.com/opengovsg/letters/assets/12240377/9daf59f0-75d6-41d7-b183-4c7bf0ac402b">

