### PR TITLE
refactor: types for bulk letter validation errors

### DIFF
--- a/backend/src/letters/letters-validation.service.ts
+++ b/backend/src/letters/letters-validation.service.ts
@@ -1,21 +1,20 @@
 import { Injectable } from '@nestjs/common'
 
 import { BULK_MAX_ROW_LENGTH } from '~shared/constants/letters'
-import { LetterParamMaps } from '~shared/dtos/letters.dto'
-
-class ValidationResult {
-  success: boolean
-  message: string
-  errors?: object[]
-}
+import {
+  BulkLetterValidationResultDto,
+  BulkLetterValidationResultError,
+  BulkLetterValidationResultErrorMessage,
+  LetterParamMaps,
+} from '~shared/dtos/letters.dto'
 
 @Injectable()
 export class LettersValidationService {
   validateBulk(
     fields: string[],
     letterParamMaps: LetterParamMaps,
-  ): ValidationResult {
-    const errorArray = []
+  ): BulkLetterValidationResultDto {
+    const errorArray: BulkLetterValidationResultError[] = []
 
     if (letterParamMaps.length >= BULK_MAX_ROW_LENGTH) {
       return {
@@ -35,7 +34,7 @@ export class LettersValidationService {
           errorArray.push({
             id: i,
             param: key,
-            message: 'Invalid attribute in param',
+            message: BulkLetterValidationResultErrorMessage.INVALID_ATTRIBUTE,
           })
         }
       }
@@ -48,7 +47,7 @@ export class LettersValidationService {
           errorArray.push({
             id: i,
             param: field,
-            message: 'Missing param',
+            message: BulkLetterValidationResultErrorMessage.MISSING_PARAM,
           })
         }
       }

--- a/shared/src/dtos/letters.dto.ts
+++ b/shared/src/dtos/letters.dto.ts
@@ -20,6 +20,23 @@ export class CreateBulkLetterDto {
   letterParamMaps: LetterParamMaps
 }
 
+export enum BulkLetterValidationResultErrorMessage {
+  INVALID_ATTRIBUTE = 'Invalid attribute in param',
+  MISSING_PARAM = 'Missing param',
+}
+
+export class BulkLetterValidationResultError {
+  id: number
+  param: string
+  message: BulkLetterValidationResultErrorMessage
+}
+
+export class BulkLetterValidationResultDto {
+  success: boolean
+  message: string
+  errors?: BulkLetterValidationResultError[]
+}
+
 export class GetLetterPublicDto {
   publicId: string
   issuedLetter: string


### PR DESCRIPTION
## Context

We want to implement the error flow, where users can see the validation errors in the CSV they uploaded

But the validation error types currently reside only in the backend, and so it's not usable by the frontend

Part of [Notion task](https://www.notion.so/opengov/Eng-bulk-creation-error-handling-31e044846ff049f09ed4cfc2f4db0b8a?pvs=4)

## Approach

Define the validation error types and move them to `/shared`, so that it can be used by the frontend in the future

