### PR TITLE
chore: disable datadog rum on public routes

### DIFF
--- a/frontend/src/features/tinymce/components/Editor.tsx
+++ b/frontend/src/features/tinymce/components/Editor.tsx
@@ -23,13 +23,23 @@ export const Editor = ({
   // tinymce not enabled
   if (!tinymceApiKey) {
     return (
-      <Box border="1px" borderColor="grey.200" bg="white">
+      <Box
+        border="1px"
+        borderColor="grey.200"
+        bg="white"
+        className="dd-privacy-hidden"
+      >
         <div dangerouslySetInnerHTML={{ __html: html }}></div>
       </Box>
     )
   }
   return (
-    <Box border="1px" borderColor="grey.200" bg="white">
+    <Box
+      border="1px"
+      borderColor="grey.200"
+      bg="white"
+      className="dd-privacy-hidden"
+    >
       <TinymceEditor
         apiKey={tinymceApiKey}
         initialValue={html}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 
-import { initDatadog } from '~lib/monitoring'
-
 import App from './app'
 import * as serviceWorker from './serviceWorker'
-
-initDatadog()
 
 const root = createRoot(document.getElementById('root') as HTMLElement)
 root.render(

--- a/frontend/src/layouts/AdminLayout/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout/AdminLayout.tsx
@@ -1,11 +1,16 @@
 import { Box, VStack } from '@chakra-ui/react'
+import { datadogRum } from '@datadog/browser-rum'
 import { Outlet } from 'react-router-dom'
 
 import { AppFooter } from '~/app/AppFooter'
 import { Sidebar } from '~/components/Sidebar'
 import { Navbar } from '~components/Navbar/Navbar'
+import { initDatadog } from '~lib/monitoring'
 
 export const AdminLayout = () => {
+  // Initialise and enable datadog RUM and session replays for admin pages
+  initDatadog()
+  datadogRum.startSessionReplayRecording()
   return (
     <VStack minWidth="100%" align="stretch" spacing={0}>
       <Navbar />

--- a/frontend/src/layouts/PublicLayout/PublicLayout.tsx
+++ b/frontend/src/layouts/PublicLayout/PublicLayout.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, Heading, Image, Stack, VStack } from '@chakra-ui/react'
+import { datadogRum } from '@datadog/browser-rum'
 import { Link as RouterLink, Outlet } from 'react-router-dom'
 
 import { AppFooter } from '~/app/AppFooter'
@@ -6,6 +7,8 @@ import LogoSvg from '~/assets/Logo.svg'
 import { routes } from '~constants/routes'
 
 export const PublicLayout = () => {
+  // Disable datadog RUM session replays for public pages
+  datadogRum.stopSessionReplayRecording()
   return (
     <VStack minWidth="100%" align="stretch" spacing={0}>
       <Flex

--- a/frontend/src/lib/monitoring.tsx
+++ b/frontend/src/lib/monitoring.tsx
@@ -1,6 +1,10 @@
 import { datadogRum } from '@datadog/browser-rum'
 
 export function initDatadog() {
+  if (datadogRum.getInitConfiguration()) {
+    // Skip if datadog RUM has already been initialized
+    return
+  }
   datadogRum.init({
     applicationId: 'fccfa971-0a5c-4c78-b340-344b104c8b9b',
     clientToken: 'pub5e264a96230b8d2f4ee90bfe8a481f4e',
@@ -23,5 +27,9 @@ export function initDatadog() {
     //   (url) => url.startsWith('https://api.example.com'),
     // ],
   })
-  datadogRum.startSessionReplayRecording()
+  /**
+   * Note: we do not start the session replay recording here.
+   * Starting and stopping it are left to the admin and public routes respectively
+   * for greater control over when to capture replay recordings.
+   */
 }


### PR DESCRIPTION
## Context

We want to disable datadog RUM on public routes, and enable it on admin routes only. This ensures that any sensitive information on the letters page will not be sent to datadog.

Closes [Notion task](https://www.notion.so/opengov/Update-RUM-to-not-monitor-confidential-letters-40a8bc74aefc4eb597ccc7507cc177a2?pvs=4)

## Approach

Admin routes are configured to start session replay recordings, while public routes are configured to stop them. This means that public routes (such as the letters page) will not be recorded.

Also, the call to `initDatadog()` has been shifted to the admin routes only, and so it will not be called for public routes. This means that in addition to not recording session replays, a RUM session will not even start at all on public routes, which helps to save money.

For even more safety, the `dd-privacy-hidden` class has been added to the letter HTML, which hides its contents from view even if a recording takes place.

![Screenshot 2023-05-23 at 5 13 26 PM](https://github.com/opengovsg/letters/assets/41856541/87074769-d863-41f1-8b91-f9105672e796)

## Tests

- [x] Tested locally that new RUM sessions do not start on public routes
- [x] Tested locally that RUM session replays are not recorded on public routes
- [x] Tested locally that even when RUM session replays are recorded for public routes, the letter contents are hidden
- [ ] Test the above on staging