### PR TITLE
feat: show upload csv errors on bulk issue drawer

### DIFF
--- a/frontend/src/features/issue/BulkIssueDrawer.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Card,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -10,15 +11,29 @@ import {
   FormControl,
   FormErrorMessage,
   Heading,
+  HStack,
   Spacer,
+  Table,
+  TableContainer,
+  Td,
   Text,
+  Th,
+  Tr,
   useControllableState,
   VStack,
 } from '@chakra-ui/react'
 import { Attachment } from '@opengovsg/design-system-react'
+import { useState } from 'react'
+import { BiChevronRight, BiLeftArrowAlt } from 'react-icons/bi'
+import { MdError } from 'react-icons/md'
 import { useNavigate } from 'react-router-dom'
 
 import { routes } from '~constants/routes'
+import { useToast } from '~hooks/useToast'
+import {
+  BulkLetterValidationResultError,
+  BulkLetterValidationResultErrorMessage,
+} from '~shared/dtos/letters.dto'
 import { arrToCsv } from '~utils/csvUtils'
 
 import {
@@ -31,13 +46,32 @@ import useParseCsv from './hooks/useParseCsv'
 export const BulkIssueDrawer = (): JSX.Element => {
   const { templateId } = useTemplateId()
   const { template } = useGetTemplateById(templateId)
+  const [isShowUploadCsvErrors, setIsShowUploadCsvErrors] = useState(false)
+  const [uploadCsvErrors, setUploadCsvErrors] = useState<
+    BulkLetterValidationResultError[]
+  >([])
   const navigate = useNavigate()
+  const toast = useToast()
 
-  const { mutateAsync, isLoading } = useCreateBulkLetterMutation()
-  const { parsedArr, parseCsv, error } = useParseCsv()
+  const { mutateAsync, isLoading } = useCreateBulkLetterMutation({
+    onSuccess: (res) => {
+      setUploadCsvErrors([])
+      // TODO: display CSV of generated letters, as per https://www.figma.com/file/BIQ4C39L4kH3WR2cfcLxDM/Letters?type=design&node-id=657-53961&t=BYFCu62CTVRyZ5Mh-0
+      onClose()
+      toast({
+        title: `${res.length} letters created`,
+        status: 'success',
+      })
+    },
+    onError: (errors) => {
+      setUploadCsvErrors(errors)
+    },
+  })
+  const { parsedArr, parseCsv, error: parseCsvError } = useParseCsv()
   const [file, setFile] = useControllableState<File | undefined>({})
 
-  const onClose = () => navigate(routes.admin.templates)
+  const onClose = () =>
+    navigate(`/${routes.admin.index}/${routes.admin.templates}`)
 
   const downloadSample = () => {
     arrToCsv(`${template.name} Sample.csv`, template.fields)
@@ -45,7 +79,124 @@ export const BulkIssueDrawer = (): JSX.Element => {
 
   const handleSubmit = async (): Promise<void> => {
     await mutateAsync({ templateId, letterParamMaps: parsedArr })
-    onClose()
+  }
+
+  const UploadCsvErrorsTable = () => {
+    const HeaderCell = ({ children }: React.PropsWithChildren) => {
+      return (
+        <Th
+          textColor="interaction.main.default"
+          textStyle="subhead-2"
+          textTransform="none"
+          fontWeight="500"
+          fontSize="0.875rem"
+          letterSpacing="none"
+          h="4rem"
+        >
+          {children}
+        </Th>
+      )
+    }
+
+    return (
+      <TableContainer w="100%">
+        <Table variant="simple">
+          <Tr backgroundColor="interaction.main-subtle.default">
+            <HeaderCell>Row #</HeaderCell>
+            <HeaderCell>Errors</HeaderCell>
+          </Tr>
+          {uploadCsvErrors.map((error) => {
+            return (
+              // TODO: find a better key for the error
+              // TODO: group all errors of the same row number together. should this be done on the frontend or backend?
+              <Tr key={JSON.stringify(error)}>
+                {/* We add 2 because the first row with data in the CSV is row 2, even though it has index 0 */}
+                <Td>{error.id + 2}</Td>
+                <Td>
+                  {error.param}{' '}
+                  {error.message ===
+                  BulkLetterValidationResultErrorMessage.INVALID_ATTRIBUTE
+                    ? 'is not a valid attribute'
+                    : 'is missing'}
+                </Td>
+              </Tr>
+            )
+          })}
+        </Table>
+      </TableContainer>
+    )
+  }
+
+  const UploadCsvForm = () => {
+    return (
+      <FormControl isInvalid={!!parseCsvError || uploadCsvErrors.length > 0}>
+        <VStack spacing={4} align="stretch">
+          {uploadCsvErrors.length > 0 && (
+            <Card
+              borderWidth="1px"
+              boxShadow=""
+              borderColor="base.divider.medium"
+              padding="1rem"
+            >
+              <Flex
+                flexDir="row"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <HStack>
+                  <MdError color="#C03434" size="1.5rem" />
+                  <Text textStyle="h5" textColor="utility.feedback.critical">
+                    {uploadCsvErrors.length} errors detected
+                  </Text>
+                </HStack>
+                <Button
+                  variant="clear"
+                  rightIcon={<BiChevronRight size="1.5rem" />}
+                  onClick={() => setIsShowUploadCsvErrors(true)}
+                >
+                  View
+                </Button>
+              </Flex>
+            </Card>
+          )}
+          <Heading size="sm">Upload the completed .CSV file</Heading>
+          <Attachment
+            onChange={(file) => {
+              setUploadCsvErrors([])
+              setFile(file)
+              void parseCsv(file)
+            }}
+            accept={'.csv'}
+            value={file}
+            name={'fileInput'}
+            isInvalid={!!parseCsvError || uploadCsvErrors.length > 0}
+          />
+          <FormErrorMessage>{parseCsvError}</FormErrorMessage>
+          <Spacer />
+          <Flex justify="space-between">
+            <Button
+              flex="auto"
+              variant="outline"
+              isDisabled={!template?.name || !template?.fields}
+              onClick={downloadSample}
+            >
+              Download Sample CSV
+            </Button>
+            <Spacer />
+            <Button
+              flex="auto"
+              isDisabled={!(parsedArr.length > 0) || uploadCsvErrors.length > 0}
+              isLoading={isLoading}
+              type="submit"
+              // eslint-disable-next-line @typescript-eslint/no-misused-promises
+              onClick={handleSubmit}
+            >
+              Generate Letters
+            </Button>
+          </Flex>
+        </VStack>
+      </FormControl>
+    )
   }
 
   return (
@@ -53,46 +204,31 @@ export const BulkIssueDrawer = (): JSX.Element => {
       <DrawerOverlay>
         <DrawerContent>
           <DrawerCloseButton />
-          <DrawerHeader>Issue {template?.name}</DrawerHeader>
+          <DrawerHeader>
+            {isShowUploadCsvErrors ? (
+              <HStack>
+                <Button
+                  variant="clear"
+                  padding={0}
+                  minWidth={0}
+                  minHeight={0}
+                  color=""
+                  onClick={() => setIsShowUploadCsvErrors(false)}
+                >
+                  <BiLeftArrowAlt size="1.5rem" />
+                </Button>
+                <Text>{uploadCsvErrors.length} errors</Text>
+              </HStack>
+            ) : (
+              `Issue ${template?.name}`
+            )}
+          </DrawerHeader>
           <DrawerBody padding={8}>
-            <FormControl isInvalid={!!error}>
-              <VStack spacing={4} align="stretch">
-                <Heading size="sm">Upload the completed .CSV file</Heading>
-                <Attachment
-                  onChange={(file) => {
-                    setFile(file)
-                    void parseCsv(file)
-                  }}
-                  accept={'.csv'}
-                  value={file}
-                  name={'fileInput'}
-                  isInvalid={!!error}
-                />
-                <FormErrorMessage>{error}</FormErrorMessage>
-                <Spacer />
-                <Flex justify="space-between">
-                  <Button
-                    flex="auto"
-                    variant="outline"
-                    isDisabled={!template?.name || !template?.fields}
-                    onClick={downloadSample}
-                  >
-                    Download Sample CSV
-                  </Button>
-                  <Spacer />
-                  <Button
-                    flex="auto"
-                    isDisabled={!(parsedArr.length > 0)}
-                    isLoading={isLoading}
-                    type="submit"
-                    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-                    onClick={handleSubmit}
-                  >
-                    Generate Letters
-                  </Button>
-                </Flex>
-              </VStack>
-            </FormControl>
+            {isShowUploadCsvErrors ? (
+              <UploadCsvErrorsTable />
+            ) : (
+              <UploadCsvForm />
+            )}
           </DrawerBody>
         </DrawerContent>
       </DrawerOverlay>

--- a/frontend/src/features/issue/hooks/templates.hooks.ts
+++ b/frontend/src/features/issue/hooks/templates.hooks.ts
@@ -1,8 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
+import { WretchError } from 'wretch/types'
 
 import { api } from '~lib/api'
 import {
+  BulkLetterValidationResultDto,
+  BulkLetterValidationResultError,
   CreateBulkLetterDto,
   GetLetterPublicDto,
 } from '~shared/dtos/letters.dto'
@@ -28,7 +31,7 @@ export const useCreateBulkLetterMutation = ({
   onError,
 }: {
   onSuccess?: (res: GetLetterPublicDto[]) => void
-  onError?: () => void
+  onError?: (errors: BulkLetterValidationResultError[]) => void
 } = {}) => {
   const queryClient = useQueryClient()
 
@@ -45,9 +48,10 @@ export const useCreateBulkLetterMutation = ({
         await queryClient.invalidateQueries(['letters'])
         onSuccess?.(res)
       },
-      onError: (e) => {
-        console.log('error', JSON.stringify(e))
-        onError?.()
+      onError: (e: WretchError) => {
+        const err = e.json as BulkLetterValidationResultDto
+        if (!err.errors) return
+        onError?.(err.errors)
       },
     },
   )

--- a/frontend/src/features/issue/hooks/useParseCsv.tsx
+++ b/frontend/src/features/issue/hooks/useParseCsv.tsx
@@ -8,7 +8,7 @@ const useParseCsv = () => {
   )
   const [error, setError] = useState<string>('')
 
-  const parseCsv = async (file?: File | undefined): Promise<void> => {
+  const parseCsv = async (file?: File): Promise<void> => {
     setError('') // reset error
     if (!file) return
     try {


### PR DESCRIPTION
## Context

We want to show useful errors to the user when there are issues with their uploaded CSV (when issuing bulk letters)

Closes [Notion task](https://www.notion.so/opengov/Eng-bulk-creation-error-handling-31e044846ff049f09ed4cfc2f4db0b8a?pvs=4)

## Approach

Show "N errors detected" if there are errors with the uploaded CSV, and show a table containing all the rows in the uploaded CSV with errors.

Added two new frontend states to the drawer:
- `uploadCsvErrors`: stores the response errors, which corresponds to errors in the uploaded CSV
- `isShowUploadCsvErrors`: boolean that controls whether we display the main form view, or the upload csv error view (table view)
  - this boolean approach might not be the best, we'll need to refactor it once we add in the final step of downloading the generated csv

**Bugs and fixes**:
- Fixed a minor navigation bug in `onClose()`
- Discovered a minor issue: if the user provides more params than requested in the uploaded CSV, it'll be grouped and sent to the backend under `__parsed_extra` ([papaparse docs](https://www.papaparse.com/docs))

TODOs:
- Group all the errors for the same CSV row into the same table row, instead of splitting it into multiple table rows
  - This might be best implemented by making not just a frontend change, but changes to the DTO and backend response as well?
  - Hope to address this in another PR, otherwise adding it here is fine too!

## Screenshots & Videos

<img width="1339" alt="Screenshot 2023-05-24 at 6 01 58 PM" src="https://github.com/opengovsg/letters/assets/41856541/6823e86b-9dae-4123-817b-2a18e7fcd6a3">
<img width="1337" alt="Screenshot 2023-05-24 at 6 02 20 PM" src="https://github.com/opengovsg/letters/assets/41856541/b841d4ec-41e3-4623-8710-11b9d9314145">

https://github.com/opengovsg/letters/assets/41856541/120f572a-ed28-4015-b9a7-83bb6225889a


## Tests

- E2E tests, we should have this someday :(

