### PR TITLE
chore: set default otp sender name to letters

### DIFF
--- a/backend/src/config/config.schema.ts
+++ b/backend/src/config/config.schema.ts
@@ -170,7 +170,7 @@ export const schema: Schema<ConfigSchema> = {
       doc: 'Name of email sender',
       env: 'OTP_SENDER_NAME',
       format: String,
-      default: 'Starter Kit',
+      default: 'Letters',
     },
     email: {
       doc: 'Email to send OTP emails from. If POSTMANGOVSG_API_KEY is set, ensure that this email is set to `donotreply@mail.postman.gov.sg`',


### PR DESCRIPTION
![Screenshot 2023-05-25 at 5 11 57 PM](https://github.com/opengovsg/letters/assets/41856541/13650803-027d-4994-a30d-27d2ea75ca1a)

This PR changes "Starter Kit" in the OTP email to "Letters"