### PR TITLE
LogIn page for Letters

### DIFF
--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -53,7 +53,7 @@ const BaseGridLayout = (props: GridProps) => (
 // Grid area styling for the login form.
 const LoginGridArea: FC<PropsWithChildren> = ({ children }) => (
   <GridItem
-    gridColumn={{ base: '1 / 5', md: '2 / 12', lg: '7 / 12' }}
+    gridColumn={{ base: '1 / 5', md: '2 / 12', lg: '8 / 12' }}
     py="4rem"
     display="flex"
     alignItems={{ base: 'initial', lg: 'center' }}
@@ -79,13 +79,13 @@ const FooterGridArea: FC<PropsWithChildren> = ({ children }) => (
 const NonMobileSidebarGridArea: FC<PropsWithChildren> = ({ children }) => (
   <GridItem
     display={{ base: 'none', md: 'flex' }}
-    gridColumn={{ md: '1 / 13', lg: '1 / 6' }}
+    gridColumn={{ md: '2 / 12', lg: '2 / 7' }}
     h={{ md: '20.5rem', lg: 'auto' }}
     pt={{ base: '1.5rem', md: '2.5rem', lg: '3rem' }}
     pb={{ lg: '3rem' }}
     flexDir="column"
-    alignItems={{ base: 'center', lg: 'center' }}
-    justifyContent="center"
+    alignItems={{ base: 'center', lg: 'start' }}
+    justifyContent={{ base: 'start', lg: 'center' }}
   >
     {children}
   </GridItem>
@@ -131,12 +131,12 @@ export const LoginPage = (): JSX.Element => {
 
   return (
     <BackgroundBox>
-      <BaseGridLayout flex={1}>
+      <BaseGridLayout flex={1} bg="white">
         <NonMobileSidebarGridArea>
-          <Text textStyle="h1" color="white">
+          <Text textStyle="h1" marginBottom="10">
             Trusted e-letters from the Singapore Government
           </Text>
-          <Image maxW="100%" maxH="100%" src={ELetters} />
+          <Image maxW="80%" maxH="100%" src={ELetters} />
         </NonMobileSidebarGridArea>
         <LoginGridArea>
           <Box minH={{ base: 'auto', lg: '17.25rem' }} w="100%">
@@ -158,9 +158,7 @@ export const LoginPage = (): JSX.Element => {
           </Box>
         </LoginGridArea>
       </BaseGridLayout>
-      <BaseGridLayout
-        bg={{ base: 'base.canvas.brandLight', lg: 'transparent' }}
-      >
+      <BaseGridLayout bg="white">
         <FooterGridArea>
           <AppFooter variant={{ lg: 'compact' }} colorMode={'light'} />
         </FooterGridArea>

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -1,13 +1,23 @@
-import { Box, Flex, GridItem, GridProps, Text } from '@chakra-ui/react'
+import {
+  Box,
+  Flex,
+  GridItem,
+  GridProps,
+  Heading,
+  Image,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
 import { FC, PropsWithChildren, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { AppFooter } from '~/app/AppFooter'
+import ELetters from '~/assets/ELetters.svg'
+import LogoSvg from '~/assets/Logo.svg'
 import { useIsDesktop } from '~hooks/useIsDesktop'
 import { AppGrid } from '~templates/AppGrid'
 
 import { LoginForm, LoginFormInputs } from './components/LoginForm'
-import { LoginImageSvgr } from './components/LoginImageSvgr'
 import { OtpForm, OtpFormInputs } from './components/OtpForm'
 import { useAdminAuth } from './context/AdminProtectedContext'
 import {
@@ -69,12 +79,12 @@ const FooterGridArea: FC<PropsWithChildren> = ({ children }) => (
 const NonMobileSidebarGridArea: FC<PropsWithChildren> = ({ children }) => (
   <GridItem
     display={{ base: 'none', md: 'flex' }}
-    gridColumn={{ md: '1 / 13', lg: '2 / 6' }}
+    gridColumn={{ md: '1 / 13', lg: '1 / 6' }}
     h={{ md: '20.5rem', lg: 'auto' }}
     pt={{ base: '1.5rem', md: '2.5rem', lg: '3rem' }}
     pb={{ lg: '3rem' }}
     flexDir="column"
-    alignItems={{ base: 'center', lg: 'flex-end' }}
+    alignItems={{ base: 'center', lg: 'center' }}
     justifyContent="center"
   >
     {children}
@@ -123,33 +133,17 @@ export const LoginPage = (): JSX.Element => {
     <BackgroundBox>
       <BaseGridLayout flex={1}>
         <NonMobileSidebarGridArea>
-          <LoginImageSvgr maxW="100%" aria-hidden />
+          <Text textStyle="h1" color="white">
+            Trusted e-letters from the Singapore Government
+          </Text>
+          <Image maxW="100%" maxH="100%" src={ELetters} />
         </NonMobileSidebarGridArea>
         <LoginGridArea>
           <Box minH={{ base: 'auto', lg: '17.25rem' }} w="100%">
-            <Flex mb={{ base: '2.5rem', lg: 0 }} flexDir="column">
-              <Text
-                display={{ base: 'none', lg: 'initial' }}
-                textStyle="responsive-heading.heavy-1280"
-                mb="2.5rem"
-              >
-                Scaffold a starter project in minutes
-              </Text>
-              <Box display={{ base: 'initial', lg: 'none' }}>
-                <Box mb={{ base: '0.75rem', lg: '1.5rem' }}>
-                  <Text textStyle="h3">Starter Kit</Text>
-                </Box>
-                <Text
-                  textStyle={{
-                    base: 'responsive-heading.heavy',
-                    md: 'responsive-heading.heavy-480',
-                    lg: 'responsive-heading.heavy-1280',
-                  }}
-                >
-                  Scaffold a starter project in minutes
-                </Text>
-              </Box>
-            </Flex>
+            <Stack direction="row" spacing={4}>
+              <Image src={LogoSvg} maxW="10rem" mb="2.5rem" />
+              <Heading>Letters</Heading>
+            </Stack>
             {!email ? (
               <LoginForm onSubmit={handleSendOtp} />
             ) : (
@@ -168,10 +162,7 @@ export const LoginPage = (): JSX.Element => {
         bg={{ base: 'base.canvas.brandLight', lg: 'transparent' }}
       >
         <FooterGridArea>
-          <AppFooter
-            variant={{ lg: 'compact' }}
-            colorMode={isDesktop ? 'dark' : 'light'}
-          />
+          <AppFooter variant={{ lg: 'compact' }} colorMode={'light'} />
         </FooterGridArea>
       </BaseGridLayout>
     </BackgroundBox>

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -10,6 +10,7 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
 import { useIsDesktop } from '~hooks/useIsDesktop'
+import { CONTACT_US } from '~shared/constants/links'
 import { isGovSgOrWhitelistedEmail } from '~shared/decorators/is-gov-sg-or-whitelisted-email'
 
 const schema = z.object({
@@ -81,7 +82,7 @@ export const LoginForm = ({ onSubmit }: LoginFormProps): JSX.Element => {
         >
           Sign in
         </Button>
-        <Link>Have a question?</Link>
+        <Link href={CONTACT_US}>Have a question?</Link>
       </Stack>
     </form>
   )


### PR DESCRIPTION
## Context

Until now the login page had the default starter-kit design.
This PR changes that to be a Letters specific design.

Closes [OTP page login copy](https://www.notion.so/opengov/Eng-OTP-page-login-copy-fedad6d5b8524cabba5110ecda04eddc?pvs=4)

## Approach

Adopting the layout from Highway.
Using the graphics from the landing page.


## Before & After Screenshots

**BEFORE**:
<img width="1508" alt="Screenshot 2023-05-29 at 8 28 28 PM" src="https://github.com/opengovsg/letters/assets/12240377/238cf368-debb-4a2a-a093-4a4bae0c6a41">

**AFTER**:
<img width="1512" alt="Screenshot 2023-05-31 at 12 26 48 PM" src="https://github.com/opengovsg/letters/assets/12240377/5f9956b6-ef06-4806-9892-662675207fd0">

