### PR TITLE
Serve fallback image for template preview

### DIFF
--- a/frontend/src/assets/TemplatePreviewFallback.svg
+++ b/frontend/src/assets/TemplatePreviewFallback.svg
@@ -1,0 +1,9 @@
+<svg width="199" height="173" viewBox="0 0 199 173" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 11C0 4.92486 4.92487 0 11 0H153.795L199 37V162C199 168.075 194.075 173 188 173H11C4.92487 173 0 168.075 0 162V11Z" fill="white"/>
+<path d="M154.5 28V0L199 37H163.5C158.529 37 154.5 32.9706 154.5 28Z" fill="#CBCBCB"/>
+<rect x="22" y="37" width="83" height="32" rx="16" fill="#EDEDED"/>
+<rect x="22" y="85" width="164" height="6" rx="3" fill="#EDEDED"/>
+<rect x="22" y="105" width="164" height="6" rx="3" fill="#EDEDED"/>
+<rect x="22" y="125" width="164" height="6" rx="3" fill="#EDEDED"/>
+<rect x="22" y="145" width="64" height="5" rx="2.5" fill="#EDEDED"/>
+</svg>

--- a/frontend/src/features/dashboard/components/TemplateCard.tsx
+++ b/frontend/src/features/dashboard/components/TemplateCard.tsx
@@ -10,6 +10,8 @@ import {
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import TemplatePreviewFallback from '~/assets/TemplatePreviewFallback.svg'
+
 type TemplateCardProps = {
   name: string
   thumbnailS3Path: string
@@ -35,26 +37,31 @@ export const TemplateCard = (templateCardProps: TemplateCardProps) => {
             }
           : {}
       }
-      padding={5}
       width={240}
       height={zoom ? 330 : 270}
       onMouseEnter={handleMouseHover}
       onMouseLeave={handleMouseHover}
     >
-      <Flex justifyContent="center">
+      <Flex justifyContent="center" background="#F8F9F9" paddingTop={5}>
         <Image
           src={templateCardProps.thumbnailS3Path}
           width={170}
           height={170}
+          fallbackSrc={TemplatePreviewFallback}
+          borderTopRadius={'10px'}
         />
       </Flex>
-      <CardHeader>
+      <CardHeader marginLeft={5} marginRight={5}>
         <Heading size="20px">
           <Text noOfLines={2}>{templateCardProps.name}</Text>
         </Heading>
       </CardHeader>
       {zoom && (
-        <Button onClick={() => navigate(`${templateCardProps.id}/issue`)}>
+        <Button
+          onClick={() => navigate(`${templateCardProps.id}/issue`)}
+          marginLeft={5}
+          marginRight={5}
+        >
           Issue Letter
         </Button>
       )}


### PR DESCRIPTION
## Context

In case the preview image of the template can not be loaded a fallback image gets shown instead.

Closes [Default image for letter template](https://www.notion.so/opengov/Design-Default-image-for-letter-template-766e2ac94dd64058994e6eabb9ebe799?pvs=4)

## Approach

Using `fallbackSrc` on `Chakra-ui`s `Image`.

## Improvments

In order to achieve the figma design for the fallback image, it was also necessary to update the general card design to match.

## Before & After Screenshots

**BEFORE**:
<img width="715" alt="Screenshot 2023-05-29 at 1 41 29 PM" src="https://github.com/opengovsg/letters/assets/12240377/bc0dd591-646f-494d-be09-d54bde55e192">

**AFTER**:
<img width="528" alt="Screenshot 2023-05-29 at 9 58 55 PM" src="https://github.com/opengovsg/letters/assets/12240377/4c54c471-b6e6-410c-b115-8bff5e67fb25">

