### PR TITLE
Return letter link in csv after bulk creation

### DIFF
--- a/backend/src/core/dto-mappers/letter.dto-mapper.ts
+++ b/backend/src/core/dto-mappers/letter.dto-mapper.ts
@@ -1,5 +1,5 @@
 import {
-  GetBulkLettersDto,
+  GetBulkLetterDto,
   GetLetterDto,
   GetLetterPublicDto,
   LetterParamMaps,
@@ -24,13 +24,13 @@ export const mapLetterToDto = (letter: Letter): GetLetterDto => {
   }
 }
 
-export const mapLetterToGetBulkLettersDto = (
+export const mapLetterToGetBulkLetterDto = (
   letterParams: LetterParamMaps,
   letters: Letter[],
-): GetBulkLettersDto[] => {
+): GetBulkLetterDto[] => {
   return letters.map((letter, index) => ({
     ...letterParams[index],
     createdAt: letter.createdAt.toDateString(),
-    shortLink: letter.shortLink,
+    publicId: letter.publicId,
   }))
 }

--- a/backend/src/letters/letters.controller.ts
+++ b/backend/src/letters/letters.controller.ts
@@ -14,7 +14,7 @@ import {
 import {
   CreateBulkLetterDto,
   CreateLetterDto,
-  GetBulkLettersDto,
+  GetBulkLetterDto,
   GetLettersDto,
   UpdateLetterDto,
 } from '~shared/dtos/letters.dto'
@@ -23,7 +23,7 @@ import { AuthGuard } from '../auth/auth.guard'
 import { CurrentUser } from '../core/decorators/current-user.decorator'
 import {
   mapLetterToDto,
-  mapLetterToGetBulkLettersDto,
+  mapLetterToGetBulkLetterDto,
   mapLetterToPublicDto,
 } from '../core/dto-mappers/letter.dto-mapper'
 import { User } from '../database/entities'
@@ -43,9 +43,9 @@ export class LettersController {
   async bulk(
     @CurrentUser() user: User,
     @Body() bulkRequest: CreateBulkLetterDto,
-  ): Promise<GetBulkLettersDto[]> {
+  ): Promise<GetBulkLetterDto[]> {
     const letters = await this.lettersService.bulkCreate(user.id, bulkRequest)
-    return mapLetterToGetBulkLettersDto(bulkRequest.letterParamMaps, letters)
+    return mapLetterToGetBulkLetterDto(bulkRequest.letterParamMaps, letters)
   }
 
   @Get()

--- a/frontend/src/features/issue/BulkIssueDrawer.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer.tsx
@@ -37,7 +37,7 @@ import { useToast } from '~hooks/useToast'
 import {
   BulkLetterValidationResultError,
   BulkLetterValidationResultErrorMessage,
-  GetBulkLettersDto,
+  GetBulkLetterDto,
 } from '~shared/dtos/letters.dto'
 import { arrToCsv, jsonArrToCsv } from '~utils/csvUtils'
 import { pluraliseIfNeeded } from '~utils/stringUtils'
@@ -56,7 +56,7 @@ export const BulkIssueDrawer = (): JSX.Element => {
   const [uploadCsvErrors, setUploadCsvErrors] = useState<
     BulkLetterValidationResultError[]
   >([])
-  const [bulkLetters, setBulkLetters] = useState<GetBulkLettersDto[]>([])
+  const [bulkLetters, setBulkLetters] = useState<GetBulkLetterDto[]>([])
   const navigate = useNavigate()
   const toast = useToast()
 
@@ -92,7 +92,15 @@ export const BulkIssueDrawer = (): JSX.Element => {
   }
 
   const handleDownloadCsv = () => {
-    jsonArrToCsv(`${template.name}[COMPLETED].csv`, bulkLetters)
+    const bulkLettersWithLink = bulkLetters.map((letter) => {
+      const { publicId, createdAt, ...letterParams } = letter
+      return {
+        ...letterParams,
+        'Date of Issue': createdAt,
+        'Letter Link': `${document.location.host}/letters/${publicId}`,
+      }
+    })
+    jsonArrToCsv(`${template.name}[COMPLETED].csv`, bulkLettersWithLink)
     onClose()
   }
 

--- a/frontend/src/features/issue/hooks/templates.hooks.ts
+++ b/frontend/src/features/issue/hooks/templates.hooks.ts
@@ -7,7 +7,7 @@ import {
   BulkLetterValidationResultDto,
   BulkLetterValidationResultError,
   CreateBulkLetterDto,
-  GetBulkLettersDto,
+  GetBulkLetterDto,
 } from '~shared/dtos/letters.dto'
 import { GetTemplateDto } from '~shared/dtos/templates.dto'
 
@@ -30,20 +30,20 @@ export const useCreateBulkLetterMutation = ({
   onSuccess,
   onError,
 }: {
-  onSuccess?: (res: GetBulkLettersDto[]) => void
+  onSuccess?: (res: GetBulkLetterDto[]) => void
   onError?: (errors: BulkLetterValidationResultError[]) => void
 } = {}) => {
   const queryClient = useQueryClient()
 
   return useMutation(
-    async (body: CreateBulkLetterDto): Promise<GetBulkLettersDto[]> => {
+    async (body: CreateBulkLetterDto): Promise<GetBulkLetterDto[]> => {
       return await api
         .url(`/letters/bulks`)
         .post(body)
-        .json<GetBulkLettersDto[]>()
+        .json<GetBulkLetterDto[]>()
     },
     {
-      onSuccess: async (res: GetBulkLettersDto[]) => {
+      onSuccess: async (res: GetBulkLetterDto[]) => {
         // invalidate letters dashboard queries
         await queryClient.invalidateQueries(['letters'])
         onSuccess?.(res)

--- a/shared/src/dtos/letters.dto.ts
+++ b/shared/src/dtos/letters.dto.ts
@@ -55,8 +55,8 @@ export class GetLettersDto {
   count: number
 }
 
-export class GetBulkLettersDto {
-  shortLink: string
+export class GetBulkLetterDto {
+  publicId: string
   createdAt: string;
   [key: string]: string
 }


### PR DESCRIPTION
## Context

Previously no link was returned to the user.

## Approach

The bulk creation response now contains the public id of the letters.
This is used to construct the letters link on the front end before including it in the csv that the admin can download.

## Improvements:
- Rename `GetBulkLettersDto` to `GetBulkLetterDto` as that is the correct naming. Thanks Alexis for calling this out.
- Change `createdAt` and `shortlink` in the  CSV to be "Date of Issue" and "Letter Link" to be more user friendly.

## Before & After Screenshots

**BEFORE**:
![before link included](https://github.com/opengovsg/letters/assets/12240377/f06ce816-b4c9-4919-b9f8-638f87a47223)

**AFTER**:
![Screen-Recording-2023-05-29-at-1](https://github.com/opengovsg/letters/assets/12240377/ad1b507c-4220-46cd-8b96-7a5adf55f8c2)
