### PR TITLE
chore: connect datadog rum and traces

### DIFF
--- a/frontend/src/lib/monitoring.tsx
+++ b/frontend/src/lib/monitoring.tsx
@@ -15,13 +15,12 @@ export function initDatadog() {
     trackResources: true,
     trackLongTasks: true,
     defaultPrivacyLevel: 'mask-user-input',
-    // TODO: connect RUM and traces after datadog tracing is set up
-    // https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum
-    // allowedTracingUrls: [
-    //   'https://api.example.com',
-    //   /https:\/\/.*\.my-api-domain\.com/,
-    //   (url) => url.startsWith('https://api.example.com'),
-    // ],
+    allowedTracingUrls: [
+      'https://letters-stg.beta.gov.sg', // TODO: remove after migrating out of beta.gov.sg
+      'https://letters.beta.gov.sg', // TODO: remove after migrating out of beta.gov.sg
+      'https://staging.letters.gov.sg',
+      'https://letters.gov.sg',
+    ],
   })
   datadogRum.startSessionReplayRecording()
 }


### PR DESCRIPTION
## Context

We want to connect Datadog RUM with traces

Closes [Notion task](https://www.notion.so/opengov/Eng-Integrate-Datadog-RUM-and-traces-3888e18dc2e447a7a1843a01f7125dbf?pvs=4)

## Approach

Change `allowedTracingUrls`, in line with these [Datadog docs](https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum)

## Tests

- [x] Test on staging that RUM sessions are connected to traces