### PR TITLE
chore: increase publicId length to 32

### DIFF
--- a/backend/src/core/utils.ts
+++ b/backend/src/core/utils.ts
@@ -29,5 +29,5 @@ const customAlphabet = (alphabet: string, size: number) =>
 
 const ALPHABET =
   '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-const ID_LENGTH = 16
+const ID_LENGTH = 32
 export const generatePublicId = customAlphabet(ALPHABET, ID_LENGTH)


### PR DESCRIPTION
## Context

Increases length of publicId to 32 to make `publicId` more difficult to guess.

