### PR TITLE
test(e2e): setup e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
     name: Build, Test, Lint
     uses: ./.github/workflows/build.yml
 
+  test-e2e:
+    name: E2E Tests
+    uses: ./.github/workflows/e2e.yml
+
   deploy-staging:
     name: Deploy to Staging
     needs: [build]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,58 @@
+name: E2E Tests
+on:
+  workflow_call:
+
+jobs:
+  test-e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_DB: letters_test
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+      - name: Cache Node.js modules
+        uses: actions/cache@v3
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - run: npm ci
+      - name: Compile shared code for dependents
+        run: npm run --prefix shared build
+      - name: Install E2E test dependencies
+        run: npm --prefix e2e ci
+      - name: Run Playwright tests
+        run: npm run test:e2e
+        env:
+          DB_NAME: letters_test
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_USERNAME: test
+          DB_PASSWORD: test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: e2e/test-results/
+          retention-days: 7

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,1 @@
+test-results/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,22 @@
+# E2E Testing
+
+Our E2E test framework is [Playwright](https://playwright.dev), mainly for speed and parallel-by-default reasons.
+
+To run E2E tests, follow these steps:
+
+```bash
+npm install
+npm run e2e  # or npm run e2e-headed
+```
+
+## Writing tests
+
+E2E tests are located in the [tests](./tests) folder.
+
+To generate locators more easily, insert [`await page.pause()`](https://playwright.dev/docs/api/class-page#page-pause) into your test, then run `npm run e2e-headed`.
+
+## Test artifacts
+
+Test artifacts from Playwright, such as screenshots, videos, and traces, will be stored in the `test-results/` directory. Screenshots and videos will only be generated for failing tests.
+
+These artifacts are also available for download on GitHub actions.

--- a/e2e/fixtures/login.ts
+++ b/e2e/fixtures/login.ts
@@ -1,0 +1,30 @@
+import { expect } from '@playwright/test'
+import fetch from 'cross-fetch'
+import { randomInt } from 'crypto'
+import { Page } from 'playwright'
+
+export const generateTestEmail = () => {
+  const suffix = randomInt(1e14)
+  return `test-${suffix}@open.gov.sg`
+}
+
+const getOTP = async (testEmail: string) => {
+  const res = await fetch('http://localhost:1080/email', { method: 'GET' })
+  const mails = await res.json()
+  const mail = mails.find((mail) => mail.headers.to === testEmail)
+  const mailId = mail.id
+  const otp = JSON.stringify(mail.html).match(/\d{6}/)[0]
+  await fetch(`http://localhost:1080/email/${mailId}`, { method: 'DELETE' })
+  return otp
+}
+
+export const login = async (page: Page, testEmail: string) => {
+  await page.goto('/admin/login/')
+  await page.getByPlaceholder('e.g. user@agency.gov.sg').fill(testEmail)
+  await page.getByRole('button', { name: 'Sign in' }).click()
+  await expect(page.getByPlaceholder('e.g. user@agency.gov.sg')).toHaveCount(0)
+
+  const otp = await getOTP(testEmail)
+  await page.getByRole('textbox').fill(otp)
+  await page.getByRole('button', { name: 'Sign in' }).click()
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,10 @@
+import { execSync } from 'child_process'
+
+async function globalSetup(): Promise<void> {
+  // Run all migrations on CI before running E2E tests
+  if (process.env.CI) {
+    execSync('../wait-for-it.sh localhost:5432 -t 0 && npm run --prefix ../backend migration:run')
+  }
+}
+
+export default globalSetup

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,130 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "1.0.0",
+      "dependencies": {
+        "cross-fetch": "^3.1.6",
+        "playwright": "^1.34.3"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.34.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.34.3.tgz",
+      "integrity": "sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.34.3"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
+      "dev": true
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "dependencies": {
+        "node-fetch": "^2.6.11"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.34.3.tgz",
+      "integrity": "sha512-UOOVE4ZbGfGkP1KVqWTdXOmm8Pw2pBhfbmlqKMkpiRCQjL5W+J+xRQXpgutFr0iM4pWl8g0GyyASMsqjQfFohw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.34.3"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.34.3.tgz",
+      "integrity": "sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "scripts": {
+    "e2e": "npx playwright test",
+    "e2e-headed": "npx playwright test --headed"
+  },
+  "dependencies": {
+    "cross-fetch": "^3.1.6",
+    "playwright": "^1.34.3"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.34.3"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,85 @@
+import type { PlaywrightTestConfig } from '@playwright/test'
+import { devices } from '@playwright/test'
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  /* Look for test files in the "tests" directory, relative to this configuration file. */
+  testDir: './tests',
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  outputDir: './test-results',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'list',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:3000',
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'], },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { channel: 'chrome' },
+    // },
+  ],
+  globalSetup: require.resolve('./global-setup'),
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm --prefix .. run dev',
+    url: 'http://localhost:3000',
+    timeout: 200 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+}
+
+export default config

--- a/e2e/tests/login.test.ts
+++ b/e2e/tests/login.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test'
+import { generateTestEmail, login } from '../fixtures/login'
+
+test.describe('login', () => {
+  test('should login, redirect to templates page and logout', async ({ page }) => {
+    const testEmail = generateTestEmail()
+    await login(page, testEmail)
+    await expect(page).toHaveURL(/admin\/templates/)
+    await page.locator('button[name=menu-button]').click()
+    await page.getByText('Logout').click()
+    await expect(page).toHaveURL(/admin\/login/)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint": "npm run all \"npm:on-* lint\"",
     "lint:fix": "npm run all \"npm:on-* lint:fix\"",
     "test": "npm run all \"npm:on-* test\"",
+    "test:e2e": "npm run --prefix e2e e2e",
+    "test:e2e-headed": "npm run --prefix e2e e2e-headed",
     "build": "npm run on-shared build && npm run all \"npm:on-*end build\"",
     "coverage": "npm run on-backend -- test:cov && cat backend/coverage/lcov.info > lcov.info",
     "cz": "git-cz",


### PR DESCRIPTION
## Context

This PR sets up E2E tests using Playwright.

## Approach

This PR took its approach directly from https://github.com/opengovsg/highway/pull/169, which contains more context and details.

To run the E2E tests, run `npm run test:e2e[-headed]` (after running `npm install` in the `e2e/` folder).

E2E tests are currently set up to run on Chromium only.

### CI

- Database migrations, if any, are automatically run before running the E2E tests
- If any test fails, the E2E test job in `e2e.yml` uploads its test artifacts to GitHub (useful for debugging)
- It is not necessary for E2E tests to pass for the overall pipeline to pass

## Deploy Notes

**New dependencies** (in E2E folder):
- `playwright` : E2E testing framework
- `cross-fetch`: fetch library for node, used to retrieve emails from maildev running on `localhost:1080`

**New dev dependencies** (in E2E folder):
- `@playwright/test`
