### PR TITLE
Feat/preview template

### DIFF
--- a/frontend/src/components/IconButton/IconButton.tsx
+++ b/frontend/src/components/IconButton/IconButton.tsx
@@ -1,0 +1,19 @@
+import { FlexProps } from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+import { FC, MouseEventHandler } from 'react'
+
+export const IconButton: FC<FlexProps> = ({
+  onClick,
+  children,
+}): JSX.Element => (
+  <Button
+    variant="clear"
+    padding={0}
+    minWidth={0}
+    minHeight={0}
+    color=""
+    onClick={onClick as unknown as MouseEventHandler<HTMLButtonElement>}
+  >
+    {children}
+  </Button>
+)

--- a/frontend/src/components/IconButton/index.ts
+++ b/frontend/src/components/IconButton/index.ts
@@ -1,0 +1,1 @@
+export * from './IconButton'

--- a/frontend/src/features/issue/BulkIssueDrawer.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer.tsx
@@ -17,6 +17,7 @@ import {
 } from '~shared/dtos/letters.dto'
 
 import { DownloadCsv } from './BulkIssueDrawer/DownloadCsv'
+import { PreviewTemplate } from './BulkIssueDrawer/PreviewTemplate'
 import { UploadCsvErrorCard } from './BulkIssueDrawer/UploadCsvErrorCard'
 import { UploadCsvErrorsTable } from './BulkIssueDrawer/UploadCsvErrorsTable'
 import { UploadCsvForm } from './BulkIssueDrawer/UploadCsvForm'
@@ -26,6 +27,8 @@ export const BulkIssueDrawer = (): JSX.Element => {
   const { templateId } = useTemplateId()
   const { template } = useGetTemplateById(templateId)
   const navigate = useNavigate()
+
+  const [isPreviewTemplate, setIsPreviewTemplate] = useState(true)
 
   const [isShowUploadCsvErrors, setIsShowUploadCsvErrors] = useState(false)
   const [uploadCsvErrors, setUploadCsvErrors] = useState<
@@ -45,7 +48,9 @@ export const BulkIssueDrawer = (): JSX.Element => {
           <DrawerCloseButton />
           <DrawerHeader>Issue {template?.name}</DrawerHeader>
           <DrawerBody padding={8}>
-            {isShowDownloadCsv ? (
+            {isPreviewTemplate ? (
+              <PreviewTemplate onToggle={() => setIsPreviewTemplate(false)} />
+            ) : isShowDownloadCsv ? (
               <DownloadCsv
                 bulkLetters={bulkLetters}
                 onDownload={() => {

--- a/frontend/src/features/issue/BulkIssueDrawer.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer.tsx
@@ -1,15 +1,21 @@
 import {
+  Divider,
   Drawer,
   DrawerBody,
-  DrawerCloseButton,
   DrawerContent,
   DrawerHeader,
   DrawerOverlay,
+  Heading,
+  HStack,
+  Text,
   VStack,
 } from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
 import { useState } from 'react'
+import { BiLeftArrowAlt, BiX } from 'react-icons/bi'
 import { useNavigate } from 'react-router-dom'
 
+import { IconButton } from '~components/IconButton'
 import { routes } from '~constants/routes'
 import {
   BulkLetterValidationResultError,
@@ -45,8 +51,33 @@ export const BulkIssueDrawer = (): JSX.Element => {
     <Drawer size="lg" isOpen placement="right" onClose={onClose}>
       <DrawerOverlay>
         <DrawerContent>
-          <DrawerCloseButton />
-          <DrawerHeader>Issue {template?.name}</DrawerHeader>
+          <DrawerHeader style={{ paddingTop: '20px' }}>
+            {isPreviewTemplate ? (
+              <HStack>
+                <IconButton onClick={onClose}>
+                  <BiX size="1.5rem" />
+                </IconButton>
+                <Heading size="md">{template?.name}</Heading>
+              </HStack>
+            ) : (
+              <HStack>
+                <IconButton onClick={() => setIsPreviewTemplate(true)}>
+                  <BiLeftArrowAlt size="1.5rem" />
+                </IconButton>
+                <VStack alignItems="left" spacing={0}>
+                  <Heading size="md">Issue {template?.name}</Heading>
+                  <Button
+                    variant="link"
+                    padding={0}
+                    onClick={() => setIsPreviewTemplate(true)}
+                  >
+                    <Text fontSize="xs">View template</Text>
+                  </Button>
+                </VStack>
+              </HStack>
+            )}
+          </DrawerHeader>
+          <Divider />
           <DrawerBody padding={8}>
             {isPreviewTemplate ? (
               <PreviewTemplate onToggle={() => setIsPreviewTemplate(false)} />

--- a/frontend/src/features/issue/BulkIssueDrawer/PreviewTemplate.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/PreviewTemplate.tsx
@@ -1,0 +1,27 @@
+import { Box, VStack } from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+
+import { Editor } from '~features/tinymce/components/Editor'
+
+import { useGetTemplateById, useTemplateId } from '../hooks/templates.hooks'
+
+interface PreviewTemplateProps {
+  onToggle: () => void
+}
+
+export const PreviewTemplate = ({
+  onToggle,
+}: PreviewTemplateProps): JSX.Element => {
+  const { templateId } = useTemplateId()
+  const { template, isTemplatesLoading } = useGetTemplateById(templateId)
+  return (
+    <VStack spacing={8} alignItems="center" justifyContent="center">
+      <Box w="85%">
+        <Editor html={template?.html} isLoading={isTemplatesLoading} />
+      </Box>
+      <Button w="full" onClick={onToggle}>
+        Issue letter
+      </Button>
+    </VStack>
+  )
+}


### PR DESCRIPTION
## Context

This PR adds functionality to allow users to preview their templates before issuing. 

Currently pending UX review from Pranu!

Changes:
- Added PreviewTemplate component
- Added styling for header

## Before & After Screenshots

**AFTER**:
<img width="1792" alt="Screenshot 2023-05-30 at 5 53 04 PM" src="https://github.com/opengovsg/letters/assets/39231249/4d98567b-1eb1-49dd-b7de-59a2db95c62a">
<img width="1792" alt="Screenshot 2023-05-30 at 5 53 12 PM" src="https://github.com/opengovsg/letters/assets/39231249/dd93f42b-0016-4155-b5b5-5cbd4645f683">
