### PR TITLE
chore: update signup buttons to login

### DIFF
--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -10,6 +10,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { BiRightArrowAlt } from 'react-icons/bi'
+import { Link as RouterLink } from 'react-router-dom'
 
 import { AppFooter } from '~/app/AppFooter'
 import ELettersSvg from '~/assets/ELetters.svg'
@@ -18,7 +19,6 @@ import LegitmacySvg from '~/assets/landing/Legitimacy.svg'
 import OgpSuiteSvg from '~/assets/landing/OgpSuite.svg'
 import SaveTimeSvg from '~/assets/landing/SaveTime.svg'
 import { useIsDesktop } from '~/hooks/useIsDesktop'
-import { BETA_SIGNUP } from '~shared/constants/links'
 
 import { FeatureGridItem } from './components/FeatureGridItem'
 import { LandingSection } from './components/LandingSection'
@@ -51,15 +51,15 @@ export const LandingPage = (): JSX.Element => {
             <Text>
               {`Letters is a platform for Singapore Government agencies to easily create and track the issuance of personalised official e-letters to citizens via letters.gov.sg links.`}
             </Text>
-            <Link href={BETA_SIGNUP} isExternal>
+            <RouterLink to="/admin/login">
               <Button
                 w={isDesktop ? 'unset' : 'full'}
                 mt="2.5rem"
                 rightIcon={<BiRightArrowAlt />}
               >
-                Sign up for our beta
+                Issue letters
               </Button>
-            </Link>
+            </RouterLink>
           </Flex>
           <Image src={ELettersSvg} />
         </Stack>

--- a/frontend/src/features/landing/components/PublicHeader.tsx
+++ b/frontend/src/features/landing/components/PublicHeader.tsx
@@ -90,9 +90,9 @@ export const PublicHeader = (props: FlexProps): JSX.Element => {
         {PUBLIC_HEADER_LINKS.map((link, index) => (
           <PublicHeaderLink key={index} {...link} />
         ))}
-        <Link href={BETA_SIGNUP} isExternal>
-          <Button>Sign up</Button>
-        </Link>
+        <RouterLink to="/admin/login">
+          <Button>Login</Button>
+        </RouterLink>
       </HStack>
     </Flex>
   )


### PR DESCRIPTION
## Context

This PR updates the two buttons on the LandingPage to point to our OTP login page instead of our Sign Up beta form as the webapp is almost ready for testing. 

## Before & After Screenshots

**BEFORE**:
<img width="1792" alt="Screenshot 2023-06-01 at 9 32 04 AM" src="https://github.com/opengovsg/letters/assets/39231249/8d749ccc-6e61-4eef-bea0-3e84a3d6aceb">

**AFTER**:
<img width="1792" alt="Screenshot 2023-06-01 at 9 31 03 AM" src="https://github.com/opengovsg/letters/assets/39231249/17347329-1b1e-417f-9ac3-9bca4bab5c7e">

