### PR TITLE
Fix/letter view

### DIFF
--- a/frontend/src/features/tinymce/components/Editor.tsx
+++ b/frontend/src/features/tinymce/components/Editor.tsx
@@ -2,6 +2,7 @@ import { Box, Spinner } from '@chakra-ui/react'
 import { Editor as TinymceEditor } from '@tinymce/tinymce-react'
 
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
+import { HEIGHT_A4, WIDTH_A4 } from '~utils/htmlUtils'
 
 import { useTinymceApiKey } from '../hooks/tinymce.hooks'
 
@@ -26,13 +27,25 @@ export const Editor = ({
   // tinymce not enabled
   if (!tinymceApiKey) {
     return (
-      <Box border="1px" borderColor="grey.200" bg="white">
+      <Box
+        border="1px"
+        borderColor="grey.200"
+        bg="white"
+        minWidth={WIDTH_A4}
+        minHeight={HEIGHT_A4}
+      >
         <div dangerouslySetInnerHTML={{ __html: cleanHtml }}></div>
       </Box>
     )
   }
   return (
-    <Box border="1px" borderColor="grey.200" bg="white">
+    <Box
+      border="1px"
+      borderColor="grey.200"
+      bg="white"
+      minWidth={WIDTH_A4}
+      minHeight={HEIGHT_A4}
+    >
       <TinymceEditor
         apiKey={tinymceApiKey}
         initialValue={cleanHtml}

--- a/frontend/src/features/tinymce/components/Editor.tsx
+++ b/frontend/src/features/tinymce/components/Editor.tsx
@@ -31,8 +31,8 @@ export const Editor = ({
         border="1px"
         borderColor="grey.200"
         bg="white"
-        minWidth={WIDTH_A4}
-        minHeight={HEIGHT_A4}
+        minWidth={{ md: WIDTH_A4 }}
+        minHeight={{ md: HEIGHT_A4 }}
       >
         <div dangerouslySetInnerHTML={{ __html: cleanHtml }}></div>
       </Box>
@@ -43,8 +43,8 @@ export const Editor = ({
       border="1px"
       borderColor="grey.200"
       bg="white"
-      minWidth={WIDTH_A4}
-      minHeight={HEIGHT_A4}
+      minWidth={{ md: WIDTH_A4 }}
+      minHeight={{ md: HEIGHT_A4 }}
     >
       <TinymceEditor
         apiKey={tinymceApiKey}

--- a/frontend/src/utils/htmlUtils.ts
+++ b/frontend/src/utils/htmlUtils.ts
@@ -1,8 +1,8 @@
 import { jsPDF } from 'jspdf'
 
 // Pixel ratios of width to height of A4 letters
-const WIDTH_A4 = 794
-const HEIGHT_A4 = 1122
+export const WIDTH_A4 = 794
+export const HEIGHT_A4 = 1122
 
 // Additional wrapper div to resize contents of letters
 const resizeToA4Dimensions = (


### PR DESCRIPTION
## Context

This PR sets a minimum width and height for our Letters preview on screens larger than 768px, to replicate the look of the A4 page. The behavior is unaffected for smaller screen resolutions

## Screenshots
**BEFORE**
![letters-stg beta gov sg_letters_5KGrEBcA07EPYxjB](https://github.com/opengovsg/letters/assets/39231249/8d82ab92-7a3e-4dd0-a1c0-29780ec66ec8)

**AFTER**
![localhost_3000_letters_Y6aaCzLiJXpicMaiExH32ZpQQGlubpJG](https://github.com/opengovsg/letters/assets/39231249/ebcbea94-bcc5-4e70-8589-993e74877243)
