### PR TITLE
Fix/render replace all

### DIFF
--- a/backend/src/letters/letters-rendering.service.spec.ts
+++ b/backend/src/letters/letters-rendering.service.spec.ts
@@ -31,6 +31,18 @@ describe('LettersRenderingService', () => {
       expect(result.fieldValues).toEqual('{"name":"Alice","id":"123"}')
     })
 
+    it('if two of the same placeholders exist in the HTML, both should be replaced', () => {
+      const html = '<p>Dear {{name}}, your name is {{name}}.</p>'
+      const letterParamMap = { name: 'Alice' }
+
+      const result: RenderedLetter = service.render(html, letterParamMap)
+
+      expect(result.issuedLetter).toEqual(
+        '<p>Dear Alice, your name is Alice.</p>',
+      )
+      expect(result.fieldValues).toEqual('{"name":"Alice"}')
+    })
+
     it('should not throw error if letterParamMap has additional params not in HTML', () => {
       // We expect no error to be thrown as the error-throwing is handled at the validation level
       const html = '<p>Hello, {{name}}!</p>'

--- a/backend/src/letters/letters-rendering.service.ts
+++ b/backend/src/letters/letters-rendering.service.ts
@@ -17,7 +17,7 @@ export class LettersRenderingService {
     for (const key in letterParamMap) {
       const value = letterParamMap[key]
       const placeHolder = `${this.PLACE_HOLDER_PREFIX}${key}${this.PLACE_HOLDER_SUFFIX}`
-      html = html.replace(placeHolder, value)
+      html = html.replaceAll(placeHolder, value)
     }
     return { issuedLetter: html, fieldValues: JSON.stringify(letterParamMap) }
   }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -25,7 +25,10 @@
       "~shared/*": [
         "../../shared/build/*"
       ]
-    }
+    },
+    "lib": [
+      "ES2021.String", // https://stackoverflow.com/questions/63616486/property-replaceall-does-not-exist-on-type-string
+    ]
   },
   "ts-node": {
     "require": [


### PR DESCRIPTION
## Context
Clement discovered a bug where only the first appearance of a parameter gets replaced, instead of every parameter as we would expect. This is because `replace` only replaces the first appearance of the string matched, not every.

Changes:
- Changed from `replace` to `replaceAll`
- Add `"ES2021.String"` to the  Typescript compiler options as for some reason, `replaceAll` does not exist on type string otherwise
- Added tests to verify that all instances of a param replaced, not just the first one