### PR TITLE
fix: duplicate and case insensitive fields in template creation

### DIFF
--- a/backend/src/letters/letters.service.spec.ts
+++ b/backend/src/letters/letters.service.spec.ts
@@ -5,6 +5,7 @@ import { DataSource } from 'typeorm'
 import { BatchesService } from '../batches/batches.service'
 import { Batch, Letter, Template } from '../database/entities'
 import { TemplatesService } from '../templates/templates.service'
+import { TemplatesParsingService } from '../templates/templates-parsing.service'
 import { LettersService } from './letters.service'
 import { LettersRenderingService } from './letters-rendering.service'
 import { LettersSanitizationService } from './letters-sanitization.service'
@@ -18,6 +19,7 @@ describe('LettersService', () => {
       providers: [
         LettersService,
         TemplatesService,
+        TemplatesParsingService,
         BatchesService,
         LettersRenderingService,
         LettersSanitizationService,

--- a/backend/src/templates/templates-parsing.service.ts
+++ b/backend/src/templates/templates-parsing.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common'
+
+import { CreateTemplateDto } from '~shared/dtos/templates.dto'
+import { sanitizeHtml } from '~shared/util/html-sanitizer'
+import { normalizeFields, normalizeHtmlKeywords } from '~shared/util/templates'
+
+@Injectable()
+export class TemplatesParsingService {
+  processTemplate(createTemplateDto: CreateTemplateDto) {
+    const sanitizedHtml = sanitizeHtml(createTemplateDto.html)
+    createTemplateDto.fields = normalizeFields(createTemplateDto.fields)
+    createTemplateDto.html = normalizeHtmlKeywords(sanitizedHtml)
+
+    return createTemplateDto
+  }
+}

--- a/backend/src/templates/templates-parsing.service.ts
+++ b/backend/src/templates/templates-parsing.service.ts
@@ -2,14 +2,20 @@ import { Injectable } from '@nestjs/common'
 
 import { CreateTemplateDto } from '~shared/dtos/templates.dto'
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
-import { normalizeFields, normalizeHtmlKeywords } from '~shared/util/templates'
+import {
+  convertFieldsToLowerCase,
+  deduplicateFields,
+  setHtmlKeywordsToLowerCase,
+} from '~shared/util/templates'
 
 @Injectable()
 export class TemplatesParsingService {
   processTemplate(createTemplateDto: CreateTemplateDto) {
     const sanitizedHtml = sanitizeHtml(createTemplateDto.html)
-    createTemplateDto.fields = normalizeFields(createTemplateDto.fields)
-    createTemplateDto.html = normalizeHtmlKeywords(sanitizedHtml)
+    createTemplateDto.fields = deduplicateFields(
+      convertFieldsToLowerCase(createTemplateDto.fields),
+    )
+    createTemplateDto.html = setHtmlKeywordsToLowerCase(sanitizedHtml)
 
     return createTemplateDto
   }

--- a/backend/src/templates/templates.controller.spec.ts
+++ b/backend/src/templates/templates.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing'
 
 import { TemplatesController } from './templates.controller'
 import { TemplatesService } from './templates.service'
+import { TemplatesParsingService } from './templates-parsing.service'
 
 describe('TemplatesController', () => {
   let controller: TemplatesController
@@ -9,7 +10,10 @@ describe('TemplatesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TemplatesController],
-      providers: [{ provide: TemplatesService, useValue: {} }],
+      providers: [
+        { provide: TemplatesService, useValue: {} },
+        TemplatesParsingService,
+      ],
     }).compile()
 
     controller = module.get<TemplatesController>(TemplatesController)

--- a/backend/src/templates/templates.controller.ts
+++ b/backend/src/templates/templates.controller.ts
@@ -27,16 +27,6 @@ export class TemplatesController {
 
   @Post()
   async create(@Body() templateDto: CreateTemplateDto) {
-    templateDto.fields = [
-      ...new Set<string>(
-        templateDto.fields.map((field: string) => field.toLowerCase()),
-      ),
-    ]
-    templateDto.html = templateDto.html.replace(
-      TEMPLATE_KEYWORD_REGEX,
-      (match: string, keyword: string) => `{{${keyword.toLowerCase()}}}`,
-    )
-
     return await this.templatesService
       .create(templateDto)
       .then((c) => mapTemplateToDto(c))

--- a/backend/src/templates/templates.controller.ts
+++ b/backend/src/templates/templates.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
 } from '@nestjs/common'
 
+import { TEMPLATE_KEYWORD_REGEX } from '~shared/constants/regex'
 import {
   CreateTemplateDto,
   UpdateTemplateDto,
@@ -26,6 +27,16 @@ export class TemplatesController {
 
   @Post()
   async create(@Body() templateDto: CreateTemplateDto) {
+    templateDto.fields = [
+      ...new Set<string>(
+        templateDto.fields.map((field: string) => field.toLowerCase()),
+      ),
+    ]
+    templateDto.html = templateDto.html.replace(
+      TEMPLATE_KEYWORD_REGEX,
+      (match: string, keyword: string) => `{{${keyword.toLowerCase()}}}`,
+    )
+
     return await this.templatesService
       .create(templateDto)
       .then((c) => mapTemplateToDto(c))

--- a/backend/src/templates/templates.module.ts
+++ b/backend/src/templates/templates.module.ts
@@ -5,11 +5,12 @@ import { AuthModule } from '../auth/auth.module'
 import { Template } from '../database/entities'
 import { TemplatesController } from './templates.controller'
 import { TemplatesService } from './templates.service'
+import { TemplatesParsingService } from './templates-parsing.service'
 
 @Module({
   imports: [TypeOrmModule.forFeature([Template]), AuthModule],
   controllers: [TemplatesController],
-  providers: [TemplatesService],
+  providers: [TemplatesService, TemplatesParsingService],
   exports: [TemplatesService, TypeOrmModule],
 })
 export class TemplatesModule {}

--- a/backend/src/templates/templates.service.spec.ts
+++ b/backend/src/templates/templates.service.spec.ts
@@ -4,6 +4,7 @@ import { DataSource } from 'typeorm'
 
 import { Template } from '../database/entities'
 import { TemplatesService } from './templates.service'
+import { TemplatesParsingService } from './templates-parsing.service'
 
 describe('TemplatesService', () => {
   let service: TemplatesService
@@ -12,6 +13,7 @@ describe('TemplatesService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TemplatesService,
+        TemplatesParsingService,
         { provide: DataSource, useValue: {} },
         { provide: getRepositoryToken(Template), useValue: {} },
       ],

--- a/backend/src/templates/templates.service.ts
+++ b/backend/src/templates/templates.service.ts
@@ -6,22 +6,22 @@ import {
   CreateTemplateDto,
   UpdateTemplateDto,
 } from '~shared/dtos/templates.dto'
-import { sanitizeHtml } from '~shared/util/html-sanitizer'
-import { normalizeFields, normalizeHtmlKeywords } from '~shared/util/templates'
 
 import { Template } from '../database/entities'
+import { TemplatesParsingService } from './templates-parsing.service'
 
 @Injectable()
 export class TemplatesService {
+  constructor(
+    private readonly templatesParsingService: TemplatesParsingService,
+  ) {}
+
   @InjectRepository(Template)
   private repository: Repository<Template>
   async create(createTemplateDto: CreateTemplateDto): Promise<Template> {
-    const processedCreateTemplateDto = {
-      ...createTemplateDto,
-      fields: normalizeFields(createTemplateDto.fields),
-      html: normalizeHtmlKeywords(sanitizeHtml(createTemplateDto.html)),
-    }
-    const template = this.repository.create(processedCreateTemplateDto)
+    const template = this.repository.create(
+      this.templatesParsingService.processTemplate(createTemplateDto),
+    )
     return await this.repository.save(template)
   }
 

--- a/backend/src/templates/templates.service.ts
+++ b/backend/src/templates/templates.service.ts
@@ -7,6 +7,7 @@ import {
   UpdateTemplateDto,
 } from '~shared/dtos/templates.dto'
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
+import { normalizeFields, normalizeHtmlKeywords } from '~shared/util/templates'
 
 import { Template } from '../database/entities'
 
@@ -15,11 +16,12 @@ export class TemplatesService {
   @InjectRepository(Template)
   private repository: Repository<Template>
   async create(createTemplateDto: CreateTemplateDto): Promise<Template> {
-    const sanitizedCreateTemplateDto = {
+    const processedCreateTemplateDto = {
       ...createTemplateDto,
-      html: sanitizeHtml(createTemplateDto.html),
+      fields: normalizeFields(createTemplateDto.fields),
+      html: normalizeHtmlKeywords(sanitizeHtml(createTemplateDto.html)),
     }
-    const template = this.repository.create(sanitizedCreateTemplateDto)
+    const template = this.repository.create(processedCreateTemplateDto)
     return await this.repository.save(template)
   }
 

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -15,6 +15,7 @@ import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 import { routes } from '~constants/routes'
+import { TEMPLATE_KEYWORD_REGEX } from '~shared/constants/regex'
 
 import { useCreateTemplateMutation } from '../hooks/create.hooks'
 
@@ -48,9 +49,9 @@ export const CreateTemplateModal = ({
 
   const getFields = (): string[] => {
     const fields: string[] = []
-    const regex = /\{\{([^{}]+)\}\}/g
-    let match
-    while ((match = regex.exec(templateContent)) !== null) {
+    let match: RegExpExecArray | null
+
+    while ((match = TEMPLATE_KEYWORD_REGEX.exec(templateContent)) !== null) {
       const field = match[1].toString().toLowerCase()
       templateContent = templateContent.replaceAll(
         `{{${match[1]}}}`,

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -55,8 +55,7 @@ export const CreateTemplateModal = ({
     while ((match = TEMPLATE_KEYWORD_REGEX.exec(templateContent)) !== null)
       if (!fields.includes(match[1])) fields.push(match[1])
 
-    const normalizedFields = normalizeFields(fields)
-    return normalizedFields
+    return normalizeFields(fields)
   }
 
   const validateName = (value: string) => {

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -16,6 +16,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { routes } from '~constants/routes'
 import { TEMPLATE_KEYWORD_REGEX } from '~shared/constants/regex'
+import { normalizeFields, normalizeHtmlKeywords } from '~shared/util/templates'
 
 import { useCreateTemplateMutation } from '../hooks/create.hooks'
 
@@ -51,15 +52,11 @@ export const CreateTemplateModal = ({
     const fields: string[] = []
     let match: RegExpExecArray | null
 
-    while ((match = TEMPLATE_KEYWORD_REGEX.exec(templateContent)) !== null) {
-      const field = match[1].toString().toLowerCase()
-      templateContent = templateContent.replaceAll(
-        `{{${match[1]}}}`,
-        `{{${field}}}`,
-      )
-      if (!fields.includes(field)) fields.push(field)
-    }
-    return fields
+    while ((match = TEMPLATE_KEYWORD_REGEX.exec(templateContent)) !== null)
+      if (!fields.includes(match[1])) fields.push(match[1])
+
+    const normalizedFields = normalizeFields(fields)
+    return normalizedFields
   }
 
   const validateName = (value: string) => {
@@ -71,7 +68,7 @@ export const CreateTemplateModal = ({
     await mutateAsync({
       name: data.templateName.trim(),
       fields: getFields(),
-      html: templateContent,
+      html: normalizeHtmlKeywords(templateContent),
       thumbnailS3Path: 'TODO',
     })
   }

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -16,7 +16,11 @@ import { useNavigate } from 'react-router-dom'
 
 import { routes } from '~constants/routes'
 import { TEMPLATE_KEYWORD_REGEX } from '~shared/constants/regex'
-import { normalizeFields, normalizeHtmlKeywords } from '~shared/util/templates'
+import {
+  convertFieldsToLowerCase,
+  deduplicateFields,
+  setHtmlKeywordsToLowerCase,
+} from '~shared/util/templates'
 
 import { useCreateTemplateMutation } from '../hooks/create.hooks'
 
@@ -55,7 +59,7 @@ export const CreateTemplateModal = ({
     while ((match = TEMPLATE_KEYWORD_REGEX.exec(templateContent)) !== null)
       if (!fields.includes(match[1])) fields.push(match[1])
 
-    return normalizeFields(fields)
+    return deduplicateFields(convertFieldsToLowerCase(fields))
   }
 
   const validateName = (value: string) => {
@@ -67,7 +71,7 @@ export const CreateTemplateModal = ({
     await mutateAsync({
       name: data.templateName.trim(),
       fields: getFields(),
-      html: normalizeHtmlKeywords(templateContent),
+      html: setHtmlKeywordsToLowerCase(templateContent),
       thumbnailS3Path: 'TODO',
     })
   }

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -18,7 +18,6 @@ import { routes } from '~constants/routes'
 import { TEMPLATE_KEYWORD_REGEX } from '~shared/constants/regex'
 import {
   convertFieldsToLowerCase,
-  deduplicateFields,
   setHtmlKeywordsToLowerCase,
 } from '~shared/util/templates'
 

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -47,11 +47,16 @@ export const CreateTemplateModal = ({
   } = useForm<FormData>()
 
   const getFields = (): string[] => {
-    const fields = []
+    const fields: string[] = []
     const regex = /\{\{([^{}]+)\}\}/g
     let match
     while ((match = regex.exec(templateContent)) !== null) {
-      fields.push(match[1])
+      const field = match[1].toString().toLowerCase()
+      templateContent = templateContent.replaceAll(
+        `{{${match[1]}}}`,
+        `{{${field}}}`,
+      )
+      if (!fields.includes(field)) fields.push(field)
     }
     return fields
   }

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -59,7 +59,7 @@ export const CreateTemplateModal = ({
     while ((match = TEMPLATE_KEYWORD_REGEX.exec(templateContent)) !== null)
       if (!fields.includes(match[1])) fields.push(match[1])
 
-    return deduplicateFields(convertFieldsToLowerCase(fields))
+    return convertFieldsToLowerCase(fields)
   }
 
   const validateName = (value: string) => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,7 +17,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "experimentalDecorators": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": false,
+    "downlevelIteration": true
   },
   "include": ["src/**/*", ".storybook/**/*", "__mocks__/**/*"],
   "exclude": ["**/jest.config.ts"]

--- a/shared/src/constants/regex.ts
+++ b/shared/src/constants/regex.ts
@@ -1,0 +1,1 @@
+export const TEMPLATE_KEYWORD_REGEX = /\{\{([^{}]+)\}\}/g

--- a/shared/src/util/__tests__/templates.spec.ts
+++ b/shared/src/util/__tests__/templates.spec.ts
@@ -1,31 +1,59 @@
-import { normalizeFields, normalizeHtmlKeywords } from '../templates'
+import {
+  convertFieldsToLowerCase,
+  deduplicateFields,
+  setHtmlKeywordsToLowerCase,
+} from '../templates'
 
-describe('Template Utils', () => {
-  describe('normalizeFields', () => {
-    it('should return an array with lowercase and unique values', () => {
-      const fields = ['Field1', 'field2', 'FIELD1', 'Field3']
-      const normalizedFields = normalizeFields(fields)
-      expect(normalizedFields).toEqual(['field1', 'field2', 'field3'])
-    })
-
-    it('should return an empty array if input is empty', () => {
-      const fields: string[] = []
-      const normalizedFields = normalizeFields(fields)
-      expect(normalizedFields).toEqual([])
-    })
+describe('convertFieldsToLowerCase', () => {
+  test('converts fields array to lowercase', () => {
+    const fields = ['Field1', 'FIELD2', 'field3']
+    const result = convertFieldsToLowerCase(fields)
+    expect(result).toEqual(['field1', 'field2', 'field3'])
   })
 
-  describe('normalizeHtmlKeywords', () => {
-    it('should replace HTML keywords with lowercase versions', () => {
-      const html = '<h1>{{KEYWORD1}}</h1><p>{{Keyword2}}</p>'
-      const normalizedHtml = normalizeHtmlKeywords(html)
-      expect(normalizedHtml).toEqual('<h1>{{keyword1}}</h1><p>{{keyword2}}</p>')
-    })
+  test('returns an empty array if input is empty', () => {
+    const fields: string[] = []
+    const result = convertFieldsToLowerCase(fields)
+    expect(result).toEqual([])
+  })
+})
 
-    it('should not modify the HTML if there are no keywords', () => {
-      const html = '<h1>This is a heading</h1><p>This is a paragraph</p>'
-      const normalizedHtml = normalizeHtmlKeywords(html)
-      expect(normalizedHtml).toEqual(html)
-    })
+describe('deduplicateFields', () => {
+  test('removes duplicate values from the fields array', () => {
+    const fields = ['field1', 'field2', 'field1', 'field2']
+    const result = deduplicateFields(fields)
+    expect(result).toEqual(['field1', 'field2'])
+  })
+
+  test('preserves the order of unique values', () => {
+    const fields = ['field1', 'field2', 'field1', 'field3', 'field2']
+    const result = deduplicateFields(fields)
+    expect(result).toEqual(['field1', 'field2', 'field3'])
+  })
+
+  test('returns an empty array if input is empty', () => {
+    const fields: string[] = []
+    const result = deduplicateFields(fields)
+    expect(result).toEqual([])
+  })
+})
+
+describe('setHtmlKeywordsToLowerCase', () => {
+  test('sets matched keywords in HTML to lowercase', () => {
+    const html = '<p>{{Keyword1}}</p><p>{{KEYWORD2}}</p>'
+    const result = setHtmlKeywordsToLowerCase(html)
+    expect(result).toEqual('<p>{{keyword1}}</p><p>{{keyword2}}</p>')
+  })
+
+  test('leaves HTML unchanged if no keywords are found', () => {
+    const html = '<p>Hello world</p>'
+    const result = setHtmlKeywordsToLowerCase(html)
+    expect(result).toEqual('<p>Hello world</p>')
+  })
+
+  test('returns an empty string if input is empty', () => {
+    const html = ''
+    const result = setHtmlKeywordsToLowerCase(html)
+    expect(result).toEqual('')
   })
 })

--- a/shared/src/util/__tests__/templates.spec.ts
+++ b/shared/src/util/__tests__/templates.spec.ts
@@ -1,0 +1,31 @@
+import { normalizeFields, normalizeHtmlKeywords } from '../templates'
+
+describe('Template Utils', () => {
+  describe('normalizeFields', () => {
+    it('should return an array with lowercase and unique values', () => {
+      const fields = ['Field1', 'field2', 'FIELD1', 'Field3']
+      const normalizedFields = normalizeFields(fields)
+      expect(normalizedFields).toEqual(['field1', 'field2', 'field3'])
+    })
+
+    it('should return an empty array if input is empty', () => {
+      const fields: string[] = []
+      const normalizedFields = normalizeFields(fields)
+      expect(normalizedFields).toEqual([])
+    })
+  })
+
+  describe('normalizeHtmlKeywords', () => {
+    it('should replace HTML keywords with lowercase versions', () => {
+      const html = '<h1>{{KEYWORD1}}</h1><p>{{Keyword2}}</p>'
+      const normalizedHtml = normalizeHtmlKeywords(html)
+      expect(normalizedHtml).toEqual('<h1>{{keyword1}}</h1><p>{{keyword2}}</p>')
+    })
+
+    it('should not modify the HTML if there are no keywords', () => {
+      const html = '<h1>This is a heading</h1><p>This is a paragraph</p>'
+      const normalizedHtml = normalizeHtmlKeywords(html)
+      expect(normalizedHtml).toEqual(html)
+    })
+  })
+})

--- a/shared/src/util/templates.ts
+++ b/shared/src/util/templates.ts
@@ -1,0 +1,14 @@
+import { TEMPLATE_KEYWORD_REGEX } from '../constants/regex'
+
+export const normalizeFields = (fields: string[]): string[] => {
+  return [
+    ...new Set<string>(fields.map((field: string) => field.toLowerCase())),
+  ]
+}
+
+export const normalizeHtmlKeywords = (html: string): string => {
+  return html.replace(
+    TEMPLATE_KEYWORD_REGEX,
+    (match: string, keyword: string) => `{{${keyword.toLowerCase()}}}`,
+  )
+}

--- a/shared/src/util/templates.ts
+++ b/shared/src/util/templates.ts
@@ -1,14 +1,14 @@
 import { TEMPLATE_KEYWORD_REGEX } from '../constants/regex'
 
-export const normalizeFields = (fields: string[]): string[] => {
-  return [
-    ...new Set<string>(fields.map((field: string) => field.toLowerCase())),
-  ]
-}
+export const convertFieldsToLowerCase = (fields: string[]): string[] =>
+  fields.map((field: string) => field.toLowerCase())
 
-export const normalizeHtmlKeywords = (html: string): string => {
-  return html.replace(
+export const deduplicateFields = (fields: string[]): string[] => [
+  ...new Set(fields),
+]
+
+export const setHtmlKeywordsToLowerCase = (html: string): string =>
+  html.replace(
     TEMPLATE_KEYWORD_REGEX,
     (match: string, keyword: string) => `{{${keyword.toLowerCase()}}}`,
   )
-}


### PR DESCRIPTION
## Context

When creating a new template, repeated fields (enclosed in double curly brackets) are added as new unique fields
## Approach

- Added shared
  - `TEMPLATE_KEYWORD_REGEX` to identify keywords in templates
  - `normalizeFields` to deduplicate and set fields to lowercase
  - `normalizeHtmlKeywords` to convert keywords in html to lowercase


- Frontend
  - Added logic to handle deduplicate and convert fields to lowercase inside the `getFields` function of `CreateTemplateModal`

- Backend
  - Added `processTemplate` function in `templates-parsing.service.ts` to store param cleaning and html parsing function
  - Updated `templates.service.ts` to call `processTemplate` before creating a new template
