### PR TITLE
Password protection (on bulk issueing)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "test",
+			"group": "test",
+			"problemMatcher": [],
+			"label": "npm: test",
+			"detail": "npm run all \"npm:on-* test\""
+		}
+	]
+}

--- a/backend/src/core/dto-mappers/letter.dto-mapper.ts
+++ b/backend/src/core/dto-mappers/letter.dto-mapper.ts
@@ -39,6 +39,6 @@ export const mapLetterToGetBulkLetterDto = (
     ? getBulkLetterDtos
     : getBulkLetterDtos.map((dtos, index) => ({
         ...dtos,
-        Password: passwords[index],
+        Password: passwords[index], // Capitalized as it is what the user expects
       }))
 }

--- a/backend/src/core/dto-mappers/letter.dto-mapper.ts
+++ b/backend/src/core/dto-mappers/letter.dto-mapper.ts
@@ -27,10 +27,18 @@ export const mapLetterToDto = (letter: Letter): GetLetterDto => {
 export const mapLetterToGetBulkLetterDto = (
   letterParams: LetterParamMaps,
   letters: Letter[],
+  passwords?: string[],
 ): GetBulkLetterDto[] => {
-  return letters.map((letter, index) => ({
+  const getBulkLetterDtos = letters.map((letter, index) => ({
     ...letterParams[index],
     createdAt: letter.createdAt.toDateString(),
     publicId: letter.publicId,
   }))
+
+  return !passwords
+    ? getBulkLetterDtos
+    : getBulkLetterDtos.map((dtos, index) => ({
+        ...dtos,
+        Password: passwords[index],
+      }))
 }

--- a/backend/src/database/entities/batch.entity.ts
+++ b/backend/src/database/entities/batch.entity.ts
@@ -24,9 +24,6 @@ export class Batch {
   @Column('int')
   userId: number
 
-  @Column('text')
-  rawCsv: string
-
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date
 }

--- a/backend/src/database/entities/letter.entity.ts
+++ b/backend/src/database/entities/letter.entity.ts
@@ -40,6 +40,9 @@ export class Letter {
   @Column('text')
   fieldValues: string
 
+  @Column('boolean')
+  isPasswordProtected: boolean
+
   @Column('text')
   shortLink: string
 

--- a/backend/src/database/migrations/1686218786357-remove-unused-rawcsv-from-batch.ts
+++ b/backend/src/database/migrations/1686218786357-remove-unused-rawcsv-from-batch.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class removeUnusedRawcsvFromBatch1686218786357
+  implements MigrationInterface
+{
+  name = 'removeUnusedRawcsvFromBatch1686218786357'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "rawCsv"`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "batches" ADD "rawCsv" text NOT NULL`)
+  }
+}

--- a/backend/src/database/migrations/1686221927894-add-is-password-protected-flag-to-letter.ts
+++ b/backend/src/database/migrations/1686221927894-add-is-password-protected-flag-to-letter.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class addIsPasswordProtectedFlagToLetter1686221927894
+  implements MigrationInterface
+{
+  name = 'addIsPasswordProtectedFlagToLetter1686221927894'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "letters" ADD "isPasswordProtected" boolean NOT NULL DEFAULT FALSE`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "letters" DROP COLUMN "isPasswordProtected"`,
+    )
+  }
+}

--- a/backend/src/letters/letters-encryption.service.ts
+++ b/backend/src/letters/letters-encryption.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common'
+import { AES } from 'crypto-js'
+
+import { RenderedLetter } from './letters-rendering.service'
+
+@Injectable()
+export class LettersEncryptionService {
+  encryptLetters(letter: RenderedLetter, password: string): RenderedLetter {
+    return {
+      fieldValues: AES.encrypt(letter.fieldValues, password).toString(),
+      issuedLetter: AES.encrypt(letter.issuedLetter, password).toString(),
+    }
+  }
+}

--- a/backend/src/letters/letters-sanitization.service.ts
+++ b/backend/src/letters/letters-sanitization.service.ts
@@ -1,14 +1,15 @@
 import { Injectable } from '@nestjs/common'
 
-import { CreateLetterDto } from '~shared/dtos/letters.dto'
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
+
+import { RenderedLetter } from './letters-rendering.service'
 
 @Injectable()
 export class LettersSanitizationService {
-  sanitizeLetter(createLetterDto: CreateLetterDto): CreateLetterDto {
+  sanitizeLetter(letter: RenderedLetter): RenderedLetter {
     return {
-      ...createLetterDto,
-      issuedLetter: sanitizeHtml(createLetterDto.issuedLetter),
+      ...letter,
+      issuedLetter: sanitizeHtml(letter.issuedLetter),
     }
   }
 }

--- a/backend/src/letters/letters-validation.service.spec.ts
+++ b/backend/src/letters/letters-validation.service.spec.ts
@@ -22,8 +22,14 @@ describe('LettersValidationService', () => {
 
     it('should validate passwords when they are enabled but none are set', () => {
       const passwords: string[] = ['']
+      const fields = ['field1']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+        },
+      ]
 
-      const result = service.validateBulk([], [], passwords)
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
 
       expect(result.success).toBe(false)
       expect(result.message).toEqual('Malformed bulk create object')
@@ -34,8 +40,20 @@ describe('LettersValidationService', () => {
 
     it('should fail when one password is missing ', () => {
       const passwords: string[] = ['hunter2', '', 'hunter2']
+      const fields = ['field1']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+      ]
 
-      const result = service.validateBulk([], [], passwords)
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
 
       expect(result.success).toBe(false)
       expect(result.message).toEqual('Malformed bulk create object')
@@ -44,10 +62,46 @@ describe('LettersValidationService', () => {
       ])
     })
 
+    it('should immediately fail the number passwords is not matching the number', () => {
+      const passwords: string[] = ['hunter2', 'hunter2', 'hunter2']
+      const fields = ['field1', 'field2', 'field3']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param3',
+        },
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param3',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual(
+        'Number of passwords does not match number of letters',
+      )
+    })
+
     it('should succeed when all passwords are provided ', () => {
       const passwords: string[] = ['hunter2', 'hunter2', 'hunter2']
+      const fields = ['field1']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+      ]
 
-      const result = service.validateBulk([], [], passwords)
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
 
       expect(result.success).toBe(true)
       expect(result.message).toEqual('Validation Success')
@@ -180,7 +234,7 @@ describe('LettersValidationService', () => {
 
   describe('validate Bulk', () => {
     it('should succeed when request data is valid', () => {
-      const passwords: string[] = ['hunter2', 'hunter2', 'hunter2']
+      const passwords: string[] = ['hunter2', 'hunter2']
       const fields = ['field1', 'field2', 'field3']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -203,7 +257,7 @@ describe('LettersValidationService', () => {
     })
 
     it('should raise errors with correct ids and messages when request data is not valid', () => {
-      const passwords: string[] = ['hunter2', 'hunter2', '']
+      const passwords: string[] = ['hunter2', '']
       const fields = ['field1', 'field2', 'field3', 'field missing']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -226,7 +280,7 @@ describe('LettersValidationService', () => {
         { id: 0, message: 'Missing param', param: 'field missing' },
         { id: 1, message: 'Missing param', param: 'field3' },
         { id: 1, message: 'Missing param', param: 'field missing' },
-        { id: 2, message: 'Missing param', param: 'Password' },
+        { id: 1, message: 'Missing param', param: 'Password' },
       ])
     })
   })

--- a/backend/src/letters/letters-validation.service.spec.ts
+++ b/backend/src/letters/letters-validation.service.spec.ts
@@ -1,0 +1,233 @@
+import { LetterParamMaps } from '~shared/dtos/letters.dto'
+
+import { LettersValidationService } from './letters-validation.service'
+
+describe('LettersValidationService', () => {
+  let service: LettersValidationService
+
+  beforeAll(() => {
+    service = new LettersValidationService()
+  })
+
+  describe('validate Passwords', () => {
+    it('should not validate passwords if none are set', () => {
+      const passwords = undefined
+
+      const result = service.validateBulk([], [], passwords)
+
+      expect(result.success).toBe(true)
+      expect(result.message).toEqual('Validation Success')
+      expect(result.errors).toBeUndefined()
+    })
+
+    it('should validate passwords when they are enabled but none are set', () => {
+      const passwords: string[] = ['']
+
+      const result = service.validateBulk([], [], passwords)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual('Malformed bulk create object')
+      expect(result.errors).toEqual([
+        { id: 0, param: 'Password', message: 'Missing param' },
+      ])
+    })
+
+    it('should fail when one password is missing ', () => {
+      const passwords: string[] = ['hunter2', '', 'hunter2']
+
+      const result = service.validateBulk([], [], passwords)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual('Malformed bulk create object')
+      expect(result.errors).toEqual([
+        { id: 1, param: 'Password', message: 'Missing param' },
+      ])
+    })
+
+    it('should succeed when all passwords are provided ', () => {
+      const passwords: string[] = ['hunter2', 'hunter2', 'hunter2']
+
+      const result = service.validateBulk([], [], passwords)
+
+      expect(result.success).toBe(true)
+      expect(result.message).toEqual('Validation Success')
+      expect(result.errors).toBeUndefined()
+    })
+  })
+
+  describe('validate letterParams exist in Template', () => {
+    it('should succeed when all params exist in template', () => {
+      const passwords = undefined
+      const fields = ['field1', 'field2', 'field3']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param3',
+        },
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param3',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(true)
+      expect(result.message).toEqual('Validation Success')
+      expect(result.errors).toBeUndefined()
+    })
+
+    it('should fail when a param is not a field in the template', () => {
+      const passwords = undefined
+      const fields = ['field1', 'field2']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+          field2: 'param2',
+          'field not in template': 'param3',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual('Malformed bulk create object')
+      expect(result.errors).toEqual([
+        {
+          id: 0,
+          message: 'Invalid attribute in param',
+          param: 'field not in template',
+        },
+      ])
+    })
+  })
+
+  describe('validate template fields are in letterParams', () => {
+    it('should succeed when all fields are present in params', () => {
+      const passwords = undefined
+      const fields = ['field1', 'field2', 'field3']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param3',
+        },
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param3',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(true)
+      expect(result.message).toEqual('Validation Success')
+      expect(result.errors).toBeUndefined()
+    })
+
+    it('should fail when a template field is not present in the params', () => {
+      const passwords = undefined
+      const fields = ['field1', 'field2', 'field3']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param2',
+        },
+        {
+          field1: 'param1',
+          field2: 'param2',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual('Malformed bulk create object')
+      expect(result.errors).toEqual([
+        { id: 1, message: 'Missing param', param: 'field3' },
+      ])
+    })
+
+    it('should fail when a param field is empty', () => {
+      const passwords = undefined
+      const fields = ['field1', 'field2', 'field3']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param2',
+        },
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: '',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual('Malformed bulk create object')
+      expect(result.errors).toEqual([
+        { id: 1, message: 'Missing param', param: 'field3' },
+      ])
+    })
+  })
+
+  describe('validate Bulk', () => {
+    it('should succeed when request data is valid', () => {
+      const passwords: string[] = ['hunter2', 'hunter2', 'hunter2']
+      const fields = ['field1', 'field2', 'field3']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param3',
+        },
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param3',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(true)
+      expect(result.message).toEqual('Validation Success')
+      expect(result.errors).toBeUndefined()
+    })
+
+    it('should raise errors with correct ids and messages when request data is not valid', () => {
+      const passwords: string[] = ['hunter2', 'hunter2', '']
+      const fields = ['field1', 'field2', 'field3', 'field missing']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: 'param3',
+        },
+        {
+          field1: 'param1',
+          field2: 'param2',
+          field3: '',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual('Malformed bulk create object')
+      expect(result.errors).toEqual([
+        { id: 0, message: 'Missing param', param: 'field missing' },
+        { id: 1, message: 'Missing param', param: 'field3' },
+        { id: 1, message: 'Missing param', param: 'field missing' },
+        { id: 2, message: 'Missing param', param: 'Password' },
+      ])
+    })
+  })
+})

--- a/backend/src/letters/letters-validation.service.ts
+++ b/backend/src/letters/letters-validation.service.ts
@@ -22,6 +22,13 @@ export class LettersValidationService {
       }
     }
 
+    if (passwords && letterParamMaps.length !== passwords?.length) {
+      return {
+        success: false,
+        message: 'Number of passwords does not match number of letters',
+      }
+    }
+
     const errors: BulkLetterValidationResultError[] = []
 
     errors.push(
@@ -45,7 +52,7 @@ export class LettersValidationService {
     return {
       success: false,
       message: 'Malformed bulk create object',
-      errors: errors,
+      errors,
     }
   }
 

--- a/backend/src/letters/letters.controller.ts
+++ b/backend/src/letters/letters.controller.ts
@@ -45,7 +45,11 @@ export class LettersController {
     @Body() bulkRequest: CreateBulkLetterDto,
   ): Promise<GetBulkLetterDto[]> {
     const letters = await this.lettersService.bulkCreate(user.id, bulkRequest)
-    return mapLetterToGetBulkLetterDto(bulkRequest.letterParamMaps, letters)
+    return mapLetterToGetBulkLetterDto(
+      bulkRequest.letterParamMaps,
+      letters,
+      bulkRequest.passwords,
+    )
   }
 
   @Get()

--- a/backend/src/letters/letters.module.ts
+++ b/backend/src/letters/letters.module.ts
@@ -7,6 +7,7 @@ import { Letter } from '../database/entities' // To be deleted
 import { TemplatesModule } from '../templates/templates.module'
 import { LettersController } from './letters.controller'
 import { LettersService } from './letters.service'
+import { LettersEncryptionService } from './letters-encryption.service'
 import { LettersRenderingService } from './letters-rendering.service'
 import { LettersSanitizationService } from './letters-sanitization.service'
 import { LettersValidationService } from './letters-validation.service'
@@ -24,6 +25,7 @@ import { LettersValidationService } from './letters-validation.service'
     LettersValidationService,
     LettersRenderingService,
     LettersSanitizationService,
+    LettersEncryptionService,
   ],
   exports: [LettersService, TypeOrmModule],
 })

--- a/backend/src/letters/letters.service.spec.ts
+++ b/backend/src/letters/letters.service.spec.ts
@@ -6,6 +6,7 @@ import { BatchesService } from '../batches/batches.service'
 import { Batch, Letter, Template } from '../database/entities'
 import { TemplatesService } from '../templates/templates.service'
 import { LettersService } from './letters.service'
+import { LettersEncryptionService } from './letters-encryption.service'
 import { LettersRenderingService } from './letters-rendering.service'
 import { LettersSanitizationService } from './letters-sanitization.service'
 import { LettersValidationService } from './letters-validation.service'
@@ -22,6 +23,7 @@ describe('LettersService', () => {
         LettersRenderingService,
         LettersSanitizationService,
         LettersValidationService,
+        LettersEncryptionService,
         { provide: DataSource, useValue: {} },
         { provide: getRepositoryToken(Letter), useValue: {} },
         { provide: getRepositoryToken(Template), useValue: {} },

--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -76,7 +76,7 @@ export class LettersService {
       this.lettersSanitizationService.sanitizeLetter(renderedLetter),
     )
 
-    const secureLetters = !passwords
+    const securedLetters = !passwords
       ? sanitizedLetters
       : sanitizedLetters.map((letter, i) =>
           this.lettersEncryptionService.encryptLetters(letter, passwords[i]),
@@ -92,9 +92,9 @@ export class LettersService {
         createBatchDto,
         entityManager,
       )
-      const lettersDto = secureLetters.map(
-        (renderedLetter: Partial<Letter>) => ({
-          ...renderedLetter,
+      const lettersDto = securedLetters.map(
+        (securedLetters: Partial<Letter>) => ({
+          ...securedLetters,
           batchId: batch.id,
           userId,
           templateId,

--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -99,6 +99,7 @@ export class LettersService {
           userId,
           templateId,
           shortLink: '',
+          isPasswordProtected: !!passwords,
         }),
       ) as CreateLetterDto[]
 

--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -55,14 +55,16 @@ export class LettersService {
     userId: number,
     createBulkLetterDto: CreateBulkLetterDto,
   ): Promise<Letter[]> {
-    const { templateId, letterParamMaps } = createBulkLetterDto
+    const { templateId, letterParamMaps, passwords } = createBulkLetterDto
     const template = await this.templatesService.findOne(templateId)
     if (!template) throw new NotFoundException('Template not found')
 
     const validationResult = this.lettersValidationService.validateBulk(
       template.fields,
       letterParamMaps,
+      passwords,
     )
+
     if (!validationResult.success)
       throw new BadRequestException(validationResult)
 
@@ -70,6 +72,7 @@ export class LettersService {
       template.html,
       letterParamMaps,
     )
+
     return await this.dataSource.transaction(async (entityManager) => {
       const createBatchDto = {
         userId,

--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -86,7 +86,6 @@ export class LettersService {
       const createBatchDto = {
         userId,
         templateId,
-        rawCsv: JSON.stringify(letterParamMaps),
       } as CreateBatchDto
 
       const batch = await this.batchesService.createWithTransaction(

--- a/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
@@ -21,7 +21,6 @@ import {
   useTemplateId,
 } from '~features/issue/hooks/templates.hooks'
 import useParseCsv from '~features/issue/hooks/useParseCsv'
-import { useToast } from '~hooks/useToast'
 import {
   BulkLetterValidationResultError,
   GetBulkLetterDto,
@@ -45,7 +44,6 @@ export const UploadCsvForm = ({
   const [file, setFile] = useControllableState<File | undefined>({})
   const [isPasswordProtected, setIsPasswordProtected] = useState(false)
 
-  const toast = useToast()
   const { parsedArr, parseCsv, error: parseCsvError, passwords } = useParseCsv()
 
   const { templateId } = useTemplateId()
@@ -59,13 +57,7 @@ export const UploadCsvForm = ({
   }
 
   const { mutateAsync, isLoading } = useCreateBulkLetterMutation({
-    onSuccess: (res: GetBulkLetterDto[]) => {
-      onSuccess(res)
-      toast({
-        title: `${res.length} ${pluraliseIfNeeded(res, 'letter')} created`,
-        status: 'success',
-      })
-    },
+    onSuccess,
     onError,
   })
 

--- a/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
@@ -46,12 +46,7 @@ export const UploadCsvForm = ({
   const [isPasswordProtected, setIsPasswordProtected] = useState(false)
 
   const toast = useToast()
-  const {
-    parsedArr,
-    parseCsv,
-    error: parseCsvError,
-    hasPasswordField,
-  } = useParseCsv()
+  const { parsedArr, parseCsv, error: parseCsvError, passwords } = useParseCsv()
 
   const { templateId } = useTemplateId()
   const { template } = useGetTemplateById(templateId)
@@ -75,7 +70,7 @@ export const UploadCsvForm = ({
   })
 
   const handleSubmit = async (): Promise<void> => {
-    await mutateAsync({ templateId, letterParamMaps: parsedArr })
+    await mutateAsync({ templateId, letterParamMaps: parsedArr, passwords })
   }
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -86,10 +81,10 @@ export const UploadCsvForm = ({
     let errorMessage = ''
     if (parseCsvError) {
       errorMessage = parseCsvError
-    } else if (!isPasswordProtected && hasPasswordField && file) {
+    } else if (!isPasswordProtected && !!passwords && file) {
       errorMessage =
         'Password field found in the CSV file despite Password protection disabled, please upload an updated .csv'
-    } else if (isPasswordProtected && !hasPasswordField && file) {
+    } else if (isPasswordProtected && !passwords && file) {
       errorMessage =
         'No Password field found in the CSV file despite Password protection enabled, please upload an updated .csv'
     }
@@ -101,7 +96,7 @@ export const UploadCsvForm = ({
       isInvalid={
         !!parseCsvError ||
         uploadCsvErrors.length > 0 ||
-        (file && hasPasswordField != isPasswordProtected)
+        (file && !!passwords != isPasswordProtected)
       }
     >
       <VStack spacing={4} align="stretch">
@@ -167,7 +162,7 @@ export const UploadCsvForm = ({
               !(parsedArr.length > 0) ||
               !!parseCsvError ||
               uploadCsvErrors.length > 0 ||
-              (isPasswordProtected !== hasPasswordField && !!file)
+              (isPasswordProtected !== !!passwords && !!file)
             }
             isLoading={isLoading}
             type="submit"

--- a/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
@@ -6,10 +6,13 @@ import {
   FormErrorMessage,
   Heading,
   Spacer,
+  Stack,
+  Text,
   useControllableState,
   VStack,
 } from '@chakra-ui/react'
-import { Attachment } from '@opengovsg/design-system-react'
+import { Attachment, Switch } from '@opengovsg/design-system-react'
+import { useState } from 'react'
 
 import { ReactComponent as CsvIcon } from '~/assets/CsvIcon.svg'
 import {
@@ -40,6 +43,7 @@ export const UploadCsvForm = ({
   reset,
 }: UploadCsvFormProps): JSX.Element => {
   const [file, setFile] = useControllableState<File | undefined>({})
+  const [isPasswordProtected, setIsPasswordProtected] = useState(false)
 
   const toast = useToast()
   const { parsedArr, parseCsv, error: parseCsvError } = useParseCsv()
@@ -48,7 +52,10 @@ export const UploadCsvForm = ({
   const { template } = useGetTemplateById(templateId)
 
   const downloadSample = () => {
-    arrToCsv(`${template.name} Sample.csv`, template.fields)
+    const csvRows = isPasswordProtected
+      ? [...template.fields, 'Password']
+      : template.fields
+    arrToCsv(`${template.name} Sample.csv`, csvRows)
   }
 
   const { mutateAsync, isLoading } = useCreateBulkLetterMutation({
@@ -64,6 +71,10 @@ export const UploadCsvForm = ({
 
   const handleSubmit = async (): Promise<void> => {
     await mutateAsync({ templateId, letterParamMaps: parsedArr })
+  }
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setIsPasswordProtected(event.target.checked)
   }
 
   return (
@@ -97,6 +108,23 @@ export const UploadCsvForm = ({
           />
         </VStack>
         <FormErrorMessage>{parseCsvError}</FormErrorMessage>
+        <Flex justify="space-between">
+          <Stack>
+            <Text fontSize="24px" fontWeight="500">
+              Add password protection
+            </Text>
+            <Text fontSize="14px" fontWeight="400">
+              Create password that citizens would have to add before accessing
+              the letter.
+            </Text>
+          </Stack>
+          <Switch
+            size="lg"
+            colorScheme="green"
+            onChange={handleChange}
+            isChecked={isPasswordProtected}
+          ></Switch>
+        </Flex>
         <Spacer />
         <Flex justify="space-between">
           <Button

--- a/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
@@ -70,7 +70,10 @@ export const UploadCsvForm = ({
   })
 
   const handleSubmit = async (): Promise<void> => {
-    await mutateAsync({ templateId, letterParamMaps: parsedArr, passwords })
+    const reqBody = isPasswordProtected
+      ? { templateId, letterParamMaps: parsedArr, passwords }
+      : { templateId, letterParamMaps: parsedArr }
+    await mutateAsync(reqBody)
   }
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -81,10 +84,10 @@ export const UploadCsvForm = ({
     let errorMessage = ''
     if (parseCsvError) {
       errorMessage = parseCsvError
-    } else if (!isPasswordProtected && !!passwords && file) {
+    } else if (!isPasswordProtected && passwords.length > 0 && file) {
       errorMessage =
         'Password field found in the CSV file despite Password protection disabled, please upload an updated .csv'
-    } else if (isPasswordProtected && !passwords && file) {
+    } else if (isPasswordProtected && passwords.length === 0 && file) {
       errorMessage =
         'No Password field found in the CSV file despite Password protection enabled, please upload an updated .csv'
     }
@@ -96,7 +99,7 @@ export const UploadCsvForm = ({
       isInvalid={
         !!parseCsvError ||
         uploadCsvErrors.length > 0 ||
-        (file && !!passwords != isPasswordProtected)
+        (file && passwords.length > 0 !== isPasswordProtected)
       }
     >
       <VStack spacing={4} align="stretch">
@@ -162,7 +165,7 @@ export const UploadCsvForm = ({
               !(parsedArr.length > 0) ||
               !!parseCsvError ||
               uploadCsvErrors.length > 0 ||
-              (isPasswordProtected !== !!passwords && !!file)
+              (isPasswordProtected !== passwords.length > 0 && !!file)
             }
             isLoading={isLoading}
             type="submit"

--- a/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
@@ -73,17 +73,17 @@ export const UploadCsvForm = ({
   }
 
   const getErrorMessage = (): string => {
-    let errorMessage = ''
+    if (!file) return ''
     if (parseCsvError) {
-      errorMessage = parseCsvError
-    } else if (!isPasswordProtected && passwords.length > 0 && file) {
-      errorMessage =
-        'Password field found in the CSV file despite Password protection disabled, please upload an updated .csv'
-    } else if (isPasswordProtected && passwords.length === 0 && file) {
-      errorMessage =
-        'No Password field found in the CSV file despite Password protection enabled, please upload an updated .csv'
+      return parseCsvError
     }
-    return errorMessage
+    if (!isPasswordProtected && passwords.length > 0) {
+      return 'Password field found in the CSV file despite Password protection disabled, please upload an updated .csv'
+    }
+    if (isPasswordProtected && passwords.length === 0) {
+      return 'No Password field found in the CSV file despite Password protection enabled, please upload an updated .csv'
+    }
+    return ''
   }
 
   return (
@@ -154,10 +154,11 @@ export const UploadCsvForm = ({
           <Button
             flex="1"
             isDisabled={
+              !file ||
               !(parsedArr.length > 0) ||
               !!parseCsvError ||
               uploadCsvErrors.length > 0 ||
-              (isPasswordProtected !== passwords.length > 0 && !!file)
+              isPasswordProtected !== passwords.length > 0
             }
             isLoading={isLoading}
             type="submit"

--- a/frontend/src/features/issue/hooks/useParseCsv.tsx
+++ b/frontend/src/features/issue/hooks/useParseCsv.tsx
@@ -7,6 +7,7 @@ const useParseCsv = () => {
     [],
   )
   const [error, setError] = useState<string>('')
+  const [hasPasswordField, setHasPasswordField] = useState(false)
 
   const parseCsv = async (file?: File): Promise<void> => {
     setError('') // reset error
@@ -15,6 +16,10 @@ const useParseCsv = () => {
       const parsedData = await csvToJsonArr(file)
       if (parsedData.length === 0) {
         setError('CSV does not contain any rows, please upload an updated .csv')
+      } else {
+        setHasPasswordField(
+          Object.hasOwn(parsedData[0] as Record<string, string>, 'Password'),
+        )
       }
       setParsedArr(parsedData as Array<{ [key: string]: string }>)
     } catch (error) {
@@ -25,8 +30,10 @@ const useParseCsv = () => {
   return {
     parsedArr,
     error,
+    hasPasswordField,
     setError,
     parseCsv,
+    setHasPasswordField,
   }
 }
 

--- a/frontend/src/features/issue/hooks/useParseCsv.tsx
+++ b/frontend/src/features/issue/hooks/useParseCsv.tsx
@@ -2,12 +2,25 @@ import { useState } from 'react'
 
 import { csvToJsonArr } from '~utils/csvUtils'
 
+function extractPasswords(parsedData: unknown[]) {
+  const passwords: string[] = []
+  ;(parsedData as Record<string, string>[]).map((row) => {
+    passwords.push(row.Password)
+    delete row.Password
+  })
+  return passwords
+}
+
+function hasPasswordField(parsedData: unknown[]) {
+  return Object.hasOwn(parsedData[0] as Record<string, string>, 'Password')
+}
+
 const useParseCsv = () => {
   const [parsedArr, setParsedArr] = useState<Array<{ [key: string]: string }>>(
     [],
   )
   const [error, setError] = useState<string>('')
-  const [hasPasswordField, setHasPasswordField] = useState(false)
+  const [passwords, setPasswords] = useState<string[]>([])
 
   const parseCsv = async (file?: File): Promise<void> => {
     setError('') // reset error
@@ -16,10 +29,8 @@ const useParseCsv = () => {
       const parsedData = await csvToJsonArr(file)
       if (parsedData.length === 0) {
         setError('CSV does not contain any rows, please upload an updated .csv')
-      } else {
-        setHasPasswordField(
-          Object.hasOwn(parsedData[0] as Record<string, string>, 'Password'),
-        )
+      } else if (hasPasswordField(parsedData)) {
+        setPasswords(extractPasswords(parsedData))
       }
       setParsedArr(parsedData as Array<{ [key: string]: string }>)
     } catch (error) {
@@ -30,10 +41,10 @@ const useParseCsv = () => {
   return {
     parsedArr,
     error,
-    hasPasswordField,
+    passwords,
     setError,
     parseCsv,
-    setHasPasswordField,
+    setPasswords,
   }
 }
 

--- a/frontend/src/features/issue/hooks/useParseCsv.tsx
+++ b/frontend/src/features/issue/hooks/useParseCsv.tsx
@@ -3,9 +3,9 @@ import { useState } from 'react'
 import { csvToJsonArr } from '~utils/csvUtils'
 
 function extractPasswords(parsedData: unknown[]) {
-  const passwords: string[] = []
-  ;(parsedData as Record<string, string>[]).map((row) => {
-    passwords.push(row.Password)
+  const passwords: string[] = Array<string>(parsedData.length)
+  ;(parsedData as Record<string, string>[]).map((row, index) => {
+    passwords[index] = row.Password
     delete row.Password
   })
   return passwords
@@ -24,6 +24,7 @@ const useParseCsv = () => {
 
   const parseCsv = async (file?: File): Promise<void> => {
     setError('') // reset error
+    setPasswords([])
     if (!file) return
     try {
       const parsedData = await csvToJsonArr(file)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       "dependencies": {
         "auto-changelog": "^2.4.0",
         "class-transformer": "^0.5.1",
-        "class-validator": "^0.14.0"
+        "class-validator": "^0.14.0",
+        "crypto-js": "^4.1.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.5.1",
@@ -1619,6 +1620,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/cz-conventional-changelog": {
       "version": "3.3.0",
@@ -7084,6 +7090,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "cz-conventional-changelog": {
       "version": "3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@types/crypto-js": "^4.1.1",
         "auto-changelog": "^2.4.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
@@ -637,6 +638,11 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "node_modules/@types/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -6400,6 +6406,11 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "@types/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA=="
     },
     "@types/json-schema": {
       "version": "7.0.11",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     }
   },
   "dependencies": {
+    "@types/crypto-js": "^4.1.1",
     "auto-changelog": "^2.4.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "auto-changelog": "^2.4.0",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.0"
+    "class-validator": "^0.14.0",
+    "crypto-js": "^4.1.1"
   }
 }

--- a/shared/src/dtos/letters.dto.ts
+++ b/shared/src/dtos/letters.dto.ts
@@ -18,6 +18,7 @@ export class CreateBulkLetterDto {
   templateId: number
   @IsDefined()
   letterParamMaps: LetterParamMaps
+  passwords: string[]
 }
 
 export enum BulkLetterValidationResultErrorMessage {

--- a/shared/src/dtos/letters.dto.ts
+++ b/shared/src/dtos/letters.dto.ts
@@ -1,4 +1,4 @@
-import { IsDefined, IsNumber } from 'class-validator'
+import { IsArray, IsDefined, IsNumber, IsOptional } from 'class-validator'
 
 export class CreateLetterDto {
   userId: number
@@ -18,7 +18,9 @@ export class CreateBulkLetterDto {
   templateId: number
   @IsDefined()
   letterParamMaps: LetterParamMaps
-  passwords: string[]
+  @IsOptional()
+  @IsArray()
+  passwords?: string[]
 }
 
 export enum BulkLetterValidationResultErrorMessage {


### PR DESCRIPTION
## Context

For Letters with sensitive information the users has asked to support password protection of letters, so that the letter can't be read by unauthorised parties.
Additionally to the password protection, this PR also encrypts each of the password protected letters (and the letter parameters) with the individual passwords as keys and does not store these keys so that only the issuing officer (the the recipient with the password) could decrypt the letter in the DB.

Closes [Notion: [Eng] Letter protection w/ password Issuing - Encryption](https://www.notion.so/opengov/Eng-Letter-protection-w-password-Issuing-Encryption-88f6df014b7646b7ba7aa43810f1377f?pvs=4)

Further details: [Notion: Letters Security](https://www.notion.so/opengov/Security-766d574464c94e0ca5c613a6b86f7cfe?pvs=4)

## Approach

- The officer provides the passwords in the csv
- The passwords are then extracted and send to the backend separately 
- On the backend the passwords are used to encrypt the letters and the letter parameters


**Improvements**:

- Refactors LettersValidationService. Adds unit test suite to ensure that it is working as expected.

- Removes unused column from `batches` table. (see details below)

- Removes toast that was hidden behind the bulk drawer.

## Before & After Screenshots

**BEFORE**:
<img width="789" alt="Screenshot 2023-06-09 at 6 10 26 PM" src="https://github.com/opengovsg/letters/assets/12240377/eee72f68-e7fa-4c75-916e-9a831eb116bb">


**AFTER**:
<img width="1507" alt="Screenshot 2023-06-09 at 6 06 25 PM" src="https://github.com/opengovsg/letters/assets/12240377/6b397e90-95bd-4a48-8a30-82b2053a111a">
<img width="688" alt="Screenshot 2023-06-09 at 6 06 49 PM" src="https://github.com/opengovsg/letters/assets/12240377/bbd7a999-81e1-45a2-adc6-f93f68ad1e49">
<img width="691" alt="Screenshot 2023-06-09 at 6 08 13 PM" src="https://github.com/opengovsg/letters/assets/12240377/c4eddc00-00e2-40a8-8ea1-92e16abd3f5a">
<img width="679" alt="Screenshot 2023-06-09 at 6 08 31 PM" src="https://github.com/opengovsg/letters/assets/12240377/a858d486-5fed-4e5f-aa3a-5fe94f6a2f48">

## Deploy Notes

- `npm i` - to get crypto-js

**New migration scripts**:

- `1686218786357-remove-unused-rawcsv-from-batch`: Removes `rawCsv` from the `batches` table as it was unused and would have been needed to be encrypted unnecessarily for each individual row for password protected letters.

- `1686221927894-add-is-password-protected-flag-to-letter`: Adds a boolean field to the letters tabls to identify letters where the parameters and rendered letter are encrypted. This defaults to false for existing letters as non of them is encrypted.


**New dependencies**:

- `crypto-js` : used for encrypting (and later decrypting letters and )


## Risks

- This breaks if the officer does not want password protection but includes a `Password` field as an actual parameter in the csv file.