### PR TITLE
Feat/letters dashboard ux

### DIFF
--- a/backend/src/core/dto-mappers/letter.dto-mapper.ts
+++ b/backend/src/core/dto-mappers/letter.dto-mapper.ts
@@ -19,8 +19,7 @@ export const mapLetterToDto = (letter: Letter): GetLetterDto => {
   return {
     templateName: letter.template.name,
     publicId: letter.publicId,
-    createdAt: letter.createdAt,
-    issuedLetter: letter.issuedLetter,
+    createdAt: letter.createdAt.toDateString(),
   }
 }
 

--- a/backend/src/core/dto-mappers/letter.dto-mapper.ts
+++ b/backend/src/core/dto-mappers/letter.dto-mapper.ts
@@ -20,6 +20,8 @@ export const mapLetterToDto = (letter: Letter): GetLetterDto => {
     templateName: letter.template.name,
     publicId: letter.publicId,
     createdAt: letter.createdAt.toDateString(),
+    isPasswordProtected: letter.isPasswordProtected,
+    issuedLetter: letter.issuedLetter,
   }
 }
 

--- a/frontend/src/features/dashboard/IssuedLettersPage.tsx
+++ b/frontend/src/features/dashboard/IssuedLettersPage.tsx
@@ -31,10 +31,9 @@ export const IssuedLettersPage = (): JSX.Element => {
       <TableContainer w="100%">
         <Table variant="simple">
           <Tr backgroundColor="interaction.main-subtle.default">
-            <HeaderCell>Template</HeaderCell>
-            <HeaderCell>Link</HeaderCell>
-            <HeaderCell>Shared with</HeaderCell>
-            <HeaderCell>Status</HeaderCell>
+            <HeaderCell>Letter link</HeaderCell>
+            <HeaderCell>Issued on</HeaderCell>
+            <HeaderCell>Template used</HeaderCell>
           </Tr>
           {letters
             ? letters.map((letter) => {
@@ -42,16 +41,18 @@ export const IssuedLettersPage = (): JSX.Element => {
                 const linkWithHost = `${document.location.host}${link}`
                 return (
                   <Tr key={letter.publicId}>
-                    <Td>{letter.templateName}</Td>
                     <Td>
-                      <Link as={RouterLink} to={link}>
+                      <Link
+                        as={RouterLink}
+                        to={link}
+                        textDecoration="none"
+                        textColor="default"
+                      >
                         {linkWithHost}
                       </Link>
                     </Td>
-                    <Td>TODO: shared with</Td>
-                    <Td>
-                      <Tag colorScheme="gray">Sent</Tag>
-                    </Td>
+                    <Td>{letter.createdAt}</Td>
+                    <Td>{letter.templateName}</Td>
                   </Tr>
                 )
               })

--- a/frontend/src/features/dashboard/IssuedLettersPage.tsx
+++ b/frontend/src/features/dashboard/IssuedLettersPage.tsx
@@ -1,14 +1,31 @@
-import { Table, TableContainer, Td, Th, Tr, VStack } from '@chakra-ui/react'
-import { Link, Pagination, Tag } from '@opengovsg/design-system-react'
+import {
+  Box,
+  Table,
+  TableContainer,
+  Td,
+  Th,
+  Tr,
+  useDisclosure,
+  VStack,
+} from '@chakra-ui/react'
+import { Link, Pagination } from '@opengovsg/design-system-react'
 import { useState } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 
 import { useGetLetters } from '~features/dashboard/hooks/dashboard.hooks'
+import { GetLetterDto } from '~shared/dtos/letters.dto'
+import { getLetterPublicLink } from '~utils/linkUtils'
+
+import { IssuedLetterDrawer } from './components/IssuedLetterDrawer'
 
 export const IssuedLettersPage = (): JSX.Element => {
   const PAGE_SIZE = 10
   const [currentPage, setCurrentPage] = useState(0)
   const { letters, count } = useGetLetters(PAGE_SIZE, currentPage * PAGE_SIZE)
+  const drawerDisclosure = useDisclosure()
+  const [selectedLetter, setSelectedLetter] = useState<
+    GetLetterDto | undefined
+  >()
 
   const HeaderCell = ({ children }: React.PropsWithChildren) => {
     return (
@@ -27,46 +44,55 @@ export const IssuedLettersPage = (): JSX.Element => {
   }
 
   return (
-    <VStack spacing="1rem" px="16px" py="1rem" align="center" w="100%">
-      <TableContainer w="100%">
-        <Table variant="simple">
-          <Tr backgroundColor="interaction.main-subtle.default">
-            <HeaderCell>Letter link</HeaderCell>
-            <HeaderCell>Issued on</HeaderCell>
-            <HeaderCell>Template used</HeaderCell>
-          </Tr>
-          {letters
-            ? letters.map((letter) => {
-                const link = `/letters/${letter.publicId}`
-                const linkWithHost = `${document.location.host}${link}`
-                return (
-                  <Tr key={letter.publicId}>
-                    <Td>
-                      <Link
-                        as={RouterLink}
-                        to={link}
-                        textDecoration="none"
-                        textColor="default"
-                      >
-                        {linkWithHost}
-                      </Link>
-                    </Td>
-                    <Td>{letter.createdAt}</Td>
-                    <Td>{letter.templateName}</Td>
-                  </Tr>
-                )
-              })
-            : null}
-        </Table>
-      </TableContainer>
-      {count && (
-        <Pagination
-          totalCount={count}
-          pageSize={PAGE_SIZE}
-          onPageChange={(newPage) => setCurrentPage(newPage - 1)}
-          currentPage={currentPage + 1}
-        />
-      )}
-    </VStack>
+    <>
+      <VStack spacing="1rem" px="16px" py="1rem" align="center" w="100%">
+        <TableContainer w="100%">
+          <Table variant="simple">
+            <Tr backgroundColor="interaction.main-subtle.default">
+              <HeaderCell>Letter link</HeaderCell>
+              <HeaderCell>Issued on</HeaderCell>
+              <HeaderCell>Template used</HeaderCell>
+            </Tr>
+            {letters &&
+              letters.map((letter) => (
+                <Box
+                  key={letter.publicId}
+                  _hover={{ background: 'gray.50' }}
+                  display="table-row"
+                  cursor="pointer"
+                  textDecoration="none"
+                  textColor="default"
+                  onClick={() => {
+                    drawerDisclosure.onOpen()
+                    setSelectedLetter(letter)
+                  }}
+                >
+                  <Td>
+                    <Link
+                      as={RouterLink}
+                      to={`/letters/${letter.publicId}`}
+                      textDecoration="none"
+                      textColor="default"
+                    >
+                      {getLetterPublicLink(letter.publicId)}
+                    </Link>
+                  </Td>
+                  <Td>{letter.createdAt}</Td>
+                  <Td>{letter.templateName}</Td>
+                </Box>
+              ))}
+          </Table>
+        </TableContainer>
+        {count && (
+          <Pagination
+            totalCount={count}
+            pageSize={PAGE_SIZE}
+            onPageChange={(newPage) => setCurrentPage(newPage - 1)}
+            currentPage={currentPage + 1}
+          />
+        )}
+      </VStack>
+      <IssuedLetterDrawer {...drawerDisclosure} letter={selectedLetter} />
+    </>
   )
 }

--- a/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
+++ b/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
@@ -9,8 +9,13 @@ import {
   Heading,
   HStack,
   Link,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
   SimpleGrid,
   Text,
+  useDisclosure,
   UseDisclosureReturn,
   VStack,
 } from '@chakra-ui/react'
@@ -47,8 +52,24 @@ export const IssuedLetterDrawer = ({
   isOpen,
   letter,
 }: IssuedLetterDrawerProp): JSX.Element => {
+  const {
+    isOpen: isPopoverOpen,
+    onOpen: onPopoverOpen,
+    onClose: onPopoverClose,
+  } = useDisclosure()
+
   if (!letter) return <></>
   const letterPublicLink = getLetterPublicLink(letter.publicId)
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(letterPublicLink)
+    onPopoverOpen()
+
+    setTimeout(() => {
+      // hide the popover after 1 second
+      onPopoverClose()
+    }, 1000)
+  }
 
   return (
     <Drawer size="lg" isOpen={isOpen} onClose={onClose}>
@@ -76,13 +97,23 @@ export const IssuedLetterDrawer = ({
                     >
                       {letterPublicLink}
                     </Link>
-                    <IconButton
-                      onClick={() => {
-                        void navigator.clipboard.writeText(letterPublicLink)
-                      }}
-                    >
-                      <BiCopy size="1.5rem" />
-                    </IconButton>
+                    <Box position="relative">
+                      <Popover isOpen={isPopoverOpen} placement="right-end">
+                        <IconButton onClick={handleCopy}>
+                          <PopoverTrigger>
+                            <BiCopy size="1.5rem" />
+                          </PopoverTrigger>
+                        </IconButton>
+                        <PopoverContent
+                          marginTop={12}
+                          maxWidth="30%"
+                          bg="grey.600"
+                          color="white"
+                        >
+                          <PopoverBody>Copied</PopoverBody>
+                        </PopoverContent>
+                      </Popover>
+                    </Box>
                   </HStack>
                 }
               />
@@ -94,7 +125,6 @@ export const IssuedLetterDrawer = ({
                 heading="Template used"
                 content={<Text>{letter.templateName}</Text>}
               />
-              {/* TODO: fix this */}
               <GridItem
                 heading="Password protection"
                 content={

--- a/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
+++ b/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
@@ -1,0 +1,96 @@
+import {
+  Divider,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Heading,
+  HStack,
+  Link,
+  SimpleGrid,
+  Text,
+  UseDisclosureReturn,
+  VStack,
+} from '@chakra-ui/react'
+import { BiCopy, BiLeftArrowAlt } from 'react-icons/bi'
+import { Link as RouterLink } from 'react-router-dom'
+
+import { IconButton } from '~components/IconButton'
+import { GetLetterDto } from '~shared/dtos/letters.dto'
+import { getLetterPublicLink } from '~utils/linkUtils'
+
+type IssuedLetterDrawerProp = UseDisclosureReturn & {
+  letter?: GetLetterDto
+}
+
+export const IssuedLetterDrawer = ({
+  onClose,
+  isOpen,
+  letter,
+}: IssuedLetterDrawerProp): JSX.Element => {
+  if (!letter) return <></>
+  const letterPublicLink = getLetterPublicLink(letter.publicId)
+
+  return (
+    <Drawer size="lg" isOpen={isOpen} onClose={onClose}>
+      <DrawerOverlay>
+        <DrawerContent>
+          <DrawerHeader paddingTop="1.25rem">
+            <HStack>
+              <IconButton onClick={onClose}>
+                <BiLeftArrowAlt size="1.5rem" />
+              </IconButton>
+              <Heading size="md">Letter details</Heading>
+            </HStack>
+          </DrawerHeader>
+          <Divider />
+          <DrawerBody paddingTop={8}>
+            <SimpleGrid columns={2} gap={8}>
+              <VStack alignItems="left">
+                <Heading size="xs" textColor="grey.500">
+                  Letter link
+                </Heading>
+                <HStack maxW="full" alignItems="center">
+                  <Link
+                    as={RouterLink}
+                    to={`/letters/${letter.publicId}`}
+                    maxW="80%"
+                  >
+                    {letterPublicLink}
+                  </Link>
+                  <IconButton
+                    onClick={() => {
+                      void navigator.clipboard.writeText(letterPublicLink)
+                    }}
+                  >
+                    <BiCopy size="1.5rem" />
+                  </IconButton>
+                </HStack>
+              </VStack>
+              <VStack alignItems="left">
+                <Heading size="xs" textColor="grey.500">
+                  Issued on
+                </Heading>
+                <Text>{letter.createdAt}</Text>
+              </VStack>
+              <VStack alignItems="left">
+                <Heading size="xs" textColor="grey.500">
+                  Template used
+                </Heading>
+                <Text>{letter.templateName}</Text>
+              </VStack>
+              <VStack alignItems="left">
+                <Heading size="xs" textColor="grey.500">
+                  Password protected
+                </Heading>
+                {/* TODO: fix this */}
+                <Text>Disabled</Text>
+              </VStack>
+            </SimpleGrid>
+          </DrawerBody>
+        </DrawerContent>
+      </DrawerOverlay>
+    </Drawer>
+  )
+}

--- a/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
+++ b/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Divider,
   Drawer,
   DrawerBody,
@@ -17,6 +18,7 @@ import { BiCopy, BiLeftArrowAlt } from 'react-icons/bi'
 import { Link as RouterLink } from 'react-router-dom'
 
 import { IconButton } from '~components/IconButton'
+import { LetterViewer } from '~features/editor/components/LetterViewer'
 import { GetLetterDto } from '~shared/dtos/letters.dto'
 import { getLetterPublicLink } from '~utils/linkUtils'
 
@@ -95,9 +97,26 @@ export const IssuedLetterDrawer = ({
               {/* TODO: fix this */}
               <GridItem
                 heading="Password protection"
-                content={<Text>Disabled</Text>}
+                content={
+                  <Text>
+                    {letter.isPasswordProtected ? 'Enabled' : 'Disabled'}
+                  </Text>
+                }
               />
             </SimpleGrid>
+            {!letter.isPasswordProtected && (
+              <Box py={8}>
+                <GridItem
+                  heading="Preview"
+                  content={
+                    <LetterViewer
+                      isLoading={false}
+                      html={letter.issuedLetter}
+                    />
+                  }
+                />
+              </Box>
+            )}
           </DrawerBody>
         </DrawerContent>
       </DrawerOverlay>

--- a/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
+++ b/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
@@ -24,6 +24,22 @@ type IssuedLetterDrawerProp = UseDisclosureReturn & {
   letter?: GetLetterDto
 }
 
+type GridItemProp = {
+  heading: string
+  content: string | JSX.Element
+}
+
+const GridItem = ({ heading, content }: GridItemProp): JSX.Element => {
+  return (
+    <VStack alignItems="left">
+      <Heading size="xs" textColor="grey.500">
+        {heading}
+      </Heading>
+      {content}
+    </VStack>
+  )
+}
+
 export const IssuedLetterDrawer = ({
   onClose,
   isOpen,
@@ -47,46 +63,40 @@ export const IssuedLetterDrawer = ({
           <Divider />
           <DrawerBody paddingTop={8}>
             <SimpleGrid columns={2} gap={8}>
-              <VStack alignItems="left">
-                <Heading size="xs" textColor="grey.500">
-                  Letter link
-                </Heading>
-                <HStack maxW="full" alignItems="center">
-                  <Link
-                    as={RouterLink}
-                    to={`/letters/${letter.publicId}`}
-                    maxW="80%"
-                  >
-                    {letterPublicLink}
-                  </Link>
-                  <IconButton
-                    onClick={() => {
-                      void navigator.clipboard.writeText(letterPublicLink)
-                    }}
-                  >
-                    <BiCopy size="1.5rem" />
-                  </IconButton>
-                </HStack>
-              </VStack>
-              <VStack alignItems="left">
-                <Heading size="xs" textColor="grey.500">
-                  Issued on
-                </Heading>
-                <Text>{letter.createdAt}</Text>
-              </VStack>
-              <VStack alignItems="left">
-                <Heading size="xs" textColor="grey.500">
-                  Template used
-                </Heading>
-                <Text>{letter.templateName}</Text>
-              </VStack>
-              <VStack alignItems="left">
-                <Heading size="xs" textColor="grey.500">
-                  Password protected
-                </Heading>
-                {/* TODO: fix this */}
-                <Text>Disabled</Text>
-              </VStack>
+              <GridItem
+                heading="Letter link"
+                content={
+                  <HStack maxW="full" alignItems="center">
+                    <Link
+                      as={RouterLink}
+                      to={`/letters/${letter.publicId}`}
+                      maxW="80%"
+                    >
+                      {letterPublicLink}
+                    </Link>
+                    <IconButton
+                      onClick={() => {
+                        void navigator.clipboard.writeText(letterPublicLink)
+                      }}
+                    >
+                      <BiCopy size="1.5rem" />
+                    </IconButton>
+                  </HStack>
+                }
+              />
+              <GridItem
+                heading="Issued on"
+                content={<Text>{letter.createdAt}</Text>}
+              />
+              <GridItem
+                heading="Template used"
+                content={<Text>{letter.templateName}</Text>}
+              />
+              {/* TODO: fix this */}
+              <GridItem
+                heading="Password protection"
+                content={<Text>Disabled</Text>}
+              />
             </SimpleGrid>
           </DrawerBody>
         </DrawerContent>

--- a/frontend/src/utils/linkUtils.ts
+++ b/frontend/src/utils/linkUtils.ts
@@ -1,0 +1,3 @@
+export const getLetterPublicLink = (publicId: string): string => {
+  return `${document.location.host}/letters/${publicId}`
+}

--- a/shared/src/dtos/letters.dto.ts
+++ b/shared/src/dtos/letters.dto.ts
@@ -50,6 +50,8 @@ export class GetLetterDto {
   templateName: string
   publicId: string
   createdAt: string
+  issuedLetter: string
+  isPasswordProtected: boolean
 }
 
 export class GetLettersDto {

--- a/shared/src/dtos/letters.dto.ts
+++ b/shared/src/dtos/letters.dto.ts
@@ -49,8 +49,7 @@ export class GetLetterPublicDto {
 export class GetLetterDto {
   templateName: string
   publicId: string
-  issuedLetter: string
-  createdAt: Date
+  createdAt: string
 }
 
 export class GetLettersDto {


### PR DESCRIPTION
## Context

This PR updates the UX of the issued letters dashboard.

**Changes:**
- Updates the backend return type for GetLettersDto to
  - Change `createdAt` to human-readable form
  - Add `isPasswordProtected` in return
- Updates the displayed columns in the issued letters tables to
  - Remove Shared with Column and Status
  - Change hover state for letter links
- Adds IssuedLetterDrawer to display more information about the issued letter
  - Adds copy functionality to the link, and copy popover
   
## Before & After Screenshots

**BEFORE**
<img width="1792" alt="Screenshot 2023-06-09 at 2 36 47 PM" src="https://github.com/opengovsg/letters/assets/39231249/33821798-a9f5-400a-b8a0-ffa853b82d68">

**AFTER**
Default state
<img width="1791" alt="Screenshot 2023-06-09 at 2 22 42 PM" src="https://github.com/opengovsg/letters/assets/39231249/bd35150c-88c5-47ea-949c-aa45190dc540">


With hover over row
<img width="1792" alt="Screenshot 2023-06-09 at 2 27 56 PM" src="https://github.com/opengovsg/letters/assets/39231249/8c4f2941-3d81-436b-91e0-178066bf1d28">
With hover over link
<img width="1792" alt="Screenshot 2023-06-09 at 2 22 59 PM"
 src="https://github.com/opengovsg/letters/assets/39231249/4143378f-c511-4e8b-acee-b6a3ab8031a7">


With drawer activated
<img width="1792" alt="Screenshot 2023-06-15 at 8 44 47 AM" src="https://github.com/opengovsg/letters/assets/39231249/5aa5f821-33f4-463e-9194-2f4eb352ee28">
With link click
<img width="1792" alt="Screenshot 2023-06-15 at 8 39 34 AM" src="https://github.com/opengovsg/letters/assets/39231249/f1b326b2-9822-4644-8557-838e3776db5f">

Full recording
https://github.com/opengovsg/letters/assets/39231249/bd569ff0-3217-4473-8e4e-9df967617f97


