### PR TITLE
feat: create template variable handling

### DIFF
--- a/backend/Letters.postman_collection.json
+++ b/backend/Letters.postman_collection.json
@@ -68,7 +68,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"html\": \"this is sample template\",\n    \"name\": \"sample template {{ placeholder1 }}\",\n    \"thumbnailS3Path\": \"s3path\",\n    \"fields\": [\"placeholder1\"]\n}",
+					"raw": "{\n    \"html\": \"this is sample template\",\n    \"name\": \"sample template {{ placeholder1 }}\",\n    \"thumbnailS3Path\": \"s3path\",\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/backend/src/letters/letters.service.spec.ts
+++ b/backend/src/letters/letters.service.spec.ts
@@ -6,6 +6,7 @@ import { BatchesService } from '../batches/batches.service'
 import { Batch, Letter, Template } from '../database/entities'
 import { TemplatesService } from '../templates/templates.service'
 import { TemplatesParsingService } from '../templates/templates-parsing.service'
+import { TemplatesSanitizationService } from '../templates/templates-sanitization.service'
 import { LettersService } from './letters.service'
 import { LettersEncryptionService } from './letters-encryption.service'
 import { LettersRenderingService } from './letters-rendering.service'
@@ -20,6 +21,7 @@ describe('LettersService', () => {
       providers: [
         LettersService,
         TemplatesService,
+        TemplatesSanitizationService,
         TemplatesParsingService,
         BatchesService,
         LettersRenderingService,

--- a/backend/src/templates/templates-parsing.service.spec.ts
+++ b/backend/src/templates/templates-parsing.service.spec.ts
@@ -16,16 +16,13 @@ describe('TemplatesParsingService', () => {
 
   describe('parseTemplate', () => {
     it('should parse the template fields and return the parsed result', () => {
-      // Arrange
       const createTemplateDto: CreateTemplateDto = {
         ...partialTemplate,
         html: 'Hello {{name}}, your email is {{email}}. Today is {{date_today}}.',
       }
 
-      // Act
       const result = templatesParsingService.parseTemplate(createTemplateDto)
 
-      // Assert
       expect(result).toEqual({
         ...createTemplateDto,
         fields: ['name', 'email', 'date_today'],
@@ -64,16 +61,13 @@ describe('TemplatesParsingService', () => {
     })
 
     it('invalid variables should be treated as plain text', () => {
-      // Arrange
       const createTemplateDto: CreateTemplateDto = {
         ...partialTemplate,
         html: 'Hello {{ Na%**123**E   }}, your email is {{keyWQ&&EI___Prd }}. Today is {{date_today}}.',
       }
 
-      // Act
       const result = templatesParsingService.parseTemplate(createTemplateDto)
 
-      // Assert
       expect(result).toEqual({
         ...createTemplateDto,
         fields: ['date_today'],

--- a/backend/src/templates/templates-parsing.service.spec.ts
+++ b/backend/src/templates/templates-parsing.service.spec.ts
@@ -1,0 +1,69 @@
+import { CreateTemplateDto } from '~shared/dtos/templates.dto'
+
+import { TemplatesParsingService } from './templates-parsing.service'
+
+describe('TemplatesParsingService', () => {
+  let templatesParsingService: TemplatesParsingService
+
+  beforeEach(() => {
+    templatesParsingService = new TemplatesParsingService()
+  })
+
+  const partialTemplate = {
+    name: 'Test Template',
+    thumbnailS3Path: 'TODO',
+  }
+
+  describe('parseTemplate', () => {
+    it('should parse the template fields and return the parsed result', () => {
+      // Arrange
+      const createTemplateDto: CreateTemplateDto = {
+        ...partialTemplate,
+        html: 'Hello {{name}}, your email is {{email}}. Today is {{date_today}}.',
+      }
+
+      // Act
+      const result = templatesParsingService.parseTemplate(createTemplateDto)
+
+      // Assert
+      expect(result).toEqual({
+        ...createTemplateDto,
+        fields: ['name', 'email', 'date_today'],
+        html: 'Hello {{name}}, your email is {{email}}. Today is {{date_today}}.',
+      })
+    })
+
+    it('should handle whitespace and lowercase fields', () => {
+      const createTemplateDto: CreateTemplateDto = {
+        ...partialTemplate,
+        html: 'Hello {{  NAME   }}, your email is {{  EMaiL   }}.',
+      }
+
+      const result = templatesParsingService.parseTemplate(createTemplateDto)
+
+      expect(result).toEqual({
+        ...createTemplateDto,
+        fields: ['name', 'email'],
+        html: 'Hello {{name}}, your email is {{email}}.',
+      })
+    })
+
+    it('invalid variables should be treated as plain text', () => {
+      // Arrange
+      const createTemplateDto: CreateTemplateDto = {
+        ...partialTemplate,
+        html: 'Hello {{ Na%**123**E   }}, your email is {{keyWQ&&EI___Prd }}. Today is {{date_today}}.',
+      }
+
+      // Act
+      const result = templatesParsingService.parseTemplate(createTemplateDto)
+
+      // Assert
+      expect(result).toEqual({
+        ...createTemplateDto,
+        fields: ['date_today'],
+        html: 'Hello {{ Na%**123**E   }}, your email is {{keyWQ&&EI___Prd }}. Today is {{date_today}}.',
+      })
+    })
+  })
+})

--- a/backend/src/templates/templates-parsing.service.spec.ts
+++ b/backend/src/templates/templates-parsing.service.spec.ts
@@ -48,6 +48,21 @@ describe('TemplatesParsingService', () => {
       })
     })
 
+    it('should deduplicate fields if there is more than one of the same field', () => {
+      const createTemplateDto: CreateTemplateDto = {
+        ...partialTemplate,
+        html: 'Hello {{  NAME   }}, your name is {{  Name   }}.',
+      }
+
+      const result = templatesParsingService.parseTemplate(createTemplateDto)
+
+      expect(result).toEqual({
+        ...createTemplateDto,
+        fields: ['name'],
+        html: 'Hello {{name}}, your name is {{name}}.',
+      })
+    })
+
     it('invalid variables should be treated as plain text', () => {
       // Arrange
       const createTemplateDto: CreateTemplateDto = {

--- a/backend/src/templates/templates-parsing.service.ts
+++ b/backend/src/templates/templates-parsing.service.ts
@@ -12,10 +12,12 @@ export class TemplatesParsingService {
     // extract valid fields
     const validFields: string[] = getTemplateFields(html)
 
-    // make fields lowercase, handle whitespace
-    const parsedFields: string[] = validFields.map((field: string) =>
-      parseTemplateField(field),
-    )
+    // make fields lowercase, handle whitespace, deduplicate
+    const parsedFields: string[] = []
+    validFields.forEach((field: string) => {
+      const parsedField = parseTemplateField(field)
+      if (!parsedFields.includes(parsedField)) parsedFields.push(parsedField)
+    })
 
     // for each valid field, replace field in html with the lowercased and trimmed version
     let parsedHtml: string = html

--- a/backend/src/templates/templates-parsing.service.ts
+++ b/backend/src/templates/templates-parsing.service.ts
@@ -1,10 +1,12 @@
-import { Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable } from '@nestjs/common'
 
 import { CreateTemplateDto } from '~shared/dtos/templates.dto'
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
 import {
   convertFieldsToLowerCase,
   deduplicateFields,
+  isFieldsInvalid,
+  isHtmlKeywordsInvalid,
   setHtmlKeywordsToLowerCase,
 } from '~shared/util/templates'
 
@@ -12,10 +14,22 @@ import {
 export class TemplatesParsingService {
   processTemplate(createTemplateDto: CreateTemplateDto) {
     const sanitizedHtml = sanitizeHtml(createTemplateDto.html)
+    createTemplateDto.html = setHtmlKeywordsToLowerCase(sanitizedHtml)
     createTemplateDto.fields = deduplicateFields(
       convertFieldsToLowerCase(createTemplateDto.fields),
     )
-    createTemplateDto.html = setHtmlKeywordsToLowerCase(sanitizedHtml)
+
+    const invalidHtml = isHtmlKeywordsInvalid(createTemplateDto.html)
+    if (invalidHtml)
+      throw new BadRequestException(
+        `Invalid html fields: ${invalidHtml.join(', ')}`,
+      )
+
+    const invalidFields = isFieldsInvalid(createTemplateDto.fields)
+    if (invalidFields)
+      throw new BadRequestException(
+        `Invalid fields: ${invalidFields.join(', ')}`,
+      )
 
     return createTemplateDto
   }

--- a/backend/src/templates/templates-parsing.service.ts
+++ b/backend/src/templates/templates-parsing.service.ts
@@ -20,12 +20,13 @@ export class TemplatesParsingService {
     )
 
     const invalidHtml = isFieldsInvalid(getHtmlFields(createTemplateDto.html))
+    const invalidFields = isFieldsInvalid(createTemplateDto.fields)
+
     if (invalidHtml)
       throw new BadRequestException(
         `Invalid html fields: ${invalidHtml.join(', ')}`,
       )
 
-    const invalidFields = isFieldsInvalid(createTemplateDto.fields)
     if (invalidFields)
       throw new BadRequestException(
         `Invalid fields: ${invalidFields.join(', ')}`,

--- a/backend/src/templates/templates-parsing.service.ts
+++ b/backend/src/templates/templates-parsing.service.ts
@@ -5,8 +5,8 @@ import { sanitizeHtml } from '~shared/util/html-sanitizer'
 import {
   convertFieldsToLowerCase,
   deduplicateFields,
+  getHtmlFields,
   isFieldsInvalid,
-  isHtmlKeywordsInvalid,
   setHtmlKeywordsToLowerCase,
 } from '~shared/util/templates'
 
@@ -19,7 +19,7 @@ export class TemplatesParsingService {
       convertFieldsToLowerCase(createTemplateDto.fields),
     )
 
-    const invalidHtml = isHtmlKeywordsInvalid(createTemplateDto.html)
+    const invalidHtml = isFieldsInvalid(getHtmlFields(createTemplateDto.html))
     if (invalidHtml)
       throw new BadRequestException(
         `Invalid html fields: ${invalidHtml.join(', ')}`,

--- a/backend/src/templates/templates-parsing.service.ts
+++ b/backend/src/templates/templates-parsing.service.ts
@@ -9,7 +9,7 @@ export class TemplatesParsingService {
   parseTemplate(createTemplateDto: CreateTemplateDto): Partial<Template> {
     const { html } = createTemplateDto
 
-    // extract valid keywords
+    // extract valid fields
     const validFields: string[] = getTemplateFields(html)
 
     // make fields lowercase, handle whitespace
@@ -17,8 +17,8 @@ export class TemplatesParsingService {
       parseTemplateField(field),
     )
 
-    // for each valid field, replace the field in the html with the parsed version
-    let parsedHtml = html
+    // for each valid field, replace field in html with the lowercased and trimmed version
+    let parsedHtml: string = html
     validFields.forEach((validField: string) => {
       parsedHtml = parsedHtml.replaceAll(
         `{{${validField}}}`,

--- a/backend/src/templates/templates-sanitization.service.ts
+++ b/backend/src/templates/templates-sanitization.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common'
+
+import { CreateTemplateDto } from '~shared/dtos/templates.dto'
+import { sanitizeHtml } from '~shared/util/html-sanitizer'
+
+@Injectable()
+export class TemplatesSanitizationService {
+  sanitizeTemplate(createTemplateDto: CreateTemplateDto): CreateTemplateDto {
+    return {
+      ...createTemplateDto,
+      html: sanitizeHtml(createTemplateDto.html),
+    }
+  }
+}

--- a/backend/src/templates/templates.controller.spec.ts
+++ b/backend/src/templates/templates.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { TemplatesController } from './templates.controller'
 import { TemplatesService } from './templates.service'
 import { TemplatesParsingService } from './templates-parsing.service'
+import { TemplatesSanitizationService } from './templates-sanitization.service'
 
 describe('TemplatesController', () => {
   let controller: TemplatesController
@@ -13,6 +14,7 @@ describe('TemplatesController', () => {
       providers: [
         { provide: TemplatesService, useValue: {} },
         TemplatesParsingService,
+        TemplatesSanitizationService,
       ],
     }).compile()
 

--- a/backend/src/templates/templates.controller.ts
+++ b/backend/src/templates/templates.controller.ts
@@ -10,7 +10,6 @@ import {
   UseGuards,
 } from '@nestjs/common'
 
-import { TEMPLATE_KEYWORD_REGEX } from '~shared/constants/regex'
 import {
   CreateTemplateDto,
   UpdateTemplateDto,

--- a/backend/src/templates/templates.module.ts
+++ b/backend/src/templates/templates.module.ts
@@ -6,11 +6,16 @@ import { Template } from '../database/entities'
 import { TemplatesController } from './templates.controller'
 import { TemplatesService } from './templates.service'
 import { TemplatesParsingService } from './templates-parsing.service'
+import { TemplatesSanitizationService } from './templates-sanitization.service'
 
 @Module({
   imports: [TypeOrmModule.forFeature([Template]), AuthModule],
   controllers: [TemplatesController],
-  providers: [TemplatesService, TemplatesParsingService],
+  providers: [
+    TemplatesService,
+    TemplatesParsingService,
+    TemplatesSanitizationService,
+  ],
   exports: [TemplatesService, TypeOrmModule],
 })
 export class TemplatesModule {}

--- a/backend/src/templates/templates.service.spec.ts
+++ b/backend/src/templates/templates.service.spec.ts
@@ -5,6 +5,7 @@ import { DataSource } from 'typeorm'
 import { Template } from '../database/entities'
 import { TemplatesService } from './templates.service'
 import { TemplatesParsingService } from './templates-parsing.service'
+import { TemplatesSanitizationService } from './templates-sanitization.service'
 
 describe('TemplatesService', () => {
   let service: TemplatesService
@@ -13,6 +14,7 @@ describe('TemplatesService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TemplatesService,
+        TemplatesSanitizationService,
         TemplatesParsingService,
         { provide: DataSource, useValue: {} },
         { provide: getRepositoryToken(Template), useValue: {} },

--- a/backend/src/templates/templates.service.ts
+++ b/backend/src/templates/templates.service.ts
@@ -9,19 +9,23 @@ import {
 
 import { Template } from '../database/entities'
 import { TemplatesParsingService } from './templates-parsing.service'
+import { TemplatesSanitizationService } from './templates-sanitization.service'
 
 @Injectable()
 export class TemplatesService {
   constructor(
+    private readonly templateSanitizationService: TemplatesSanitizationService,
     private readonly templatesParsingService: TemplatesParsingService,
   ) {}
 
   @InjectRepository(Template)
   private repository: Repository<Template>
   async create(createTemplateDto: CreateTemplateDto): Promise<Template> {
-    const template = this.repository.create(
-      this.templatesParsingService.processTemplate(createTemplateDto),
-    )
+    const sanitizedTemplate =
+      this.templateSanitizationService.sanitizeTemplate(createTemplateDto)
+    const parsedTemplate =
+      this.templatesParsingService.parseTemplate(sanitizedTemplate)
+    const template = this.repository.create(parsedTemplate)
     return await this.repository.save(template)
   }
 

--- a/frontend/src/features/create/CreateTemplatePage.tsx
+++ b/frontend/src/features/create/CreateTemplatePage.tsx
@@ -41,10 +41,7 @@ export const CreateTemplatePage = (): JSX.Element => {
           Save Template
         </Button>
       </HStack>
-      <TemplateEditor
-        html="<h1>This is a sample header</h1>You can add {{keywords}} enclosed in {{curly}} braces"
-        onContentChange={setTemplateContent}
-      />
+      <TemplateEditor onContentChange={setTemplateContent} />
       <CreateTemplateModal
         isOpen={isOpen}
         onClose={onClose}

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -55,13 +55,12 @@ export const CreateTemplateModal = ({
     tempDiv.innerHTML = content
     const spanElements = tempDiv.querySelectorAll('span')
 
-    if (spanElements)
-      spanElements.forEach((span) => {
-        if (span.parentNode) {
-          const spanText = document.createTextNode(span.innerText)
-          span.parentNode.replaceChild(spanText, span)
-        }
-      })
+    spanElements?.forEach((span) => {
+      span.parentNode?.replaceChild(
+        document.createTextNode(span.innerText),
+        span,
+      )
+    })
 
     return tempDiv.innerHTML
   }

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -80,7 +80,7 @@ export const CreateTemplateModal = ({
     return true
   }
 
-  function stripSpanTags(content: string) {
+  const stripSpanTags = (content: string) => {
     const tempDiv = document.createElement('div')
     tempDiv.innerHTML = content
     const spanElements = tempDiv.querySelectorAll('span')

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -129,7 +129,11 @@ export const CreateTemplateModal = ({
             <Button variant="ghost" onClick={onClose} border={0}>
               Cancel
             </Button>
-            <Button isLoading={isLoading} type="submit">
+            <Button
+              isLoading={isLoading}
+              type="submit"
+              isDisabled={!!errors.templateName}
+            >
               Save Template
             </Button>
           </ModalFooter>

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -18,6 +18,7 @@ import { routes } from '~constants/routes'
 import { TEMPLATE_KEYWORD_REGEX } from '~shared/constants/regex'
 import {
   convertFieldsToLowerCase,
+  isHtmlKeywordsInvalid,
   setHtmlKeywordsToLowerCase,
 } from '~shared/util/templates'
 
@@ -61,16 +62,45 @@ export const CreateTemplateModal = ({
     return convertFieldsToLowerCase(fields)
   }
 
-  const validateName = (value: string) => {
+  const validateTemplate = (value: string) => {
     if (value.trim() === '') return 'Template name cannot be empty.'
+
+    const invalidKeywords = isHtmlKeywordsInvalid(templateContent)
+
+    if (invalidKeywords) {
+      let errorMessage = 'The following keywords are invalid: '
+
+      invalidKeywords.forEach((field, index) => {
+        errorMessage += field
+        if (index !== invalidKeywords.length - 1) errorMessage += ', '
+      })
+      return errorMessage
+    }
+
     return true
+  }
+
+  function stripSpanTags(content: string) {
+    const tempDiv = document.createElement('div')
+    tempDiv.innerHTML = content
+    const spanElements = tempDiv.querySelectorAll('span')
+
+    if (spanElements)
+      spanElements.forEach((span) => {
+        if (span.parentNode) {
+          const spanText = document.createTextNode(span.innerText)
+          span.parentNode.replaceChild(spanText, span)
+        }
+      })
+
+    return tempDiv.innerHTML
   }
 
   const onSubmit = async (data: FormData): Promise<void> => {
     await mutateAsync({
       name: data.templateName.trim(),
       fields: getFields(),
-      html: setHtmlKeywordsToLowerCase(templateContent),
+      html: setHtmlKeywordsToLowerCase(stripSpanTags(templateContent)),
       thumbnailS3Path: 'TODO',
     })
   }
@@ -87,7 +117,7 @@ export const CreateTemplateModal = ({
               <Input
                 {...register('templateName', {
                   required: true,
-                  validate: validateName,
+                  validate: validateTemplate,
                 })}
               />
               <FormErrorMessage>

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -15,10 +15,6 @@ import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 import { routes } from '~constants/routes'
-import {
-  getHtmlFields,
-  setHtmlKeywordsToLowerCase,
-} from '~shared/util/templates'
 
 import { useCreateTemplateMutation } from '../hooks/create.hooks'
 
@@ -50,30 +46,10 @@ export const CreateTemplateModal = ({
     formState: { errors },
   } = useForm<FormData>()
 
-  const stripSpanTags = (content: string) => {
-    const tempDiv = document.createElement('div')
-    tempDiv.innerHTML = content
-    const spanElements = tempDiv.querySelectorAll('span')
-
-    spanElements?.forEach((span) => {
-      span.parentNode?.replaceChild(
-        document.createTextNode(span.innerText),
-        span,
-      )
-    })
-
-    return tempDiv.innerHTML
-  }
-
   const onSubmit = async (data: FormData): Promise<void> => {
-    const processedHtml = setHtmlKeywordsToLowerCase(
-      stripSpanTags(templateContent),
-    )
-
     await mutateAsync({
       name: data.templateName.trim(),
-      fields: getHtmlFields(processedHtml),
-      html: processedHtml,
+      html: templateContent,
       thumbnailS3Path: 'TODO',
     })
   }

--- a/frontend/src/features/editor/components/TemplateEditor.tsx
+++ b/frontend/src/features/editor/components/TemplateEditor.tsx
@@ -1,74 +1,36 @@
 import { Spinner } from '@chakra-ui/react'
 import { Editor as TinymceEditor } from '@tinymce/tinymce-react'
 
-import { TEMPLATE_KEYWORD_CHAR_REGEX } from '~shared/constants/regex'
-
 import { useTinymceApiKey } from '../hooks/tinymce.hooks'
 
 interface TemplateEditorProps {
+  html?: string
   onContentChange: React.Dispatch<React.SetStateAction<string>>
   isDisabled?: boolean
 }
 
 export const TemplateEditor = ({
+  html,
   onContentChange,
   isDisabled = false,
 }: TemplateEditorProps): JSX.Element => {
   const { tinymceApiKey, isLoadingTinymceApiKey } = useTinymceApiKey()
   if (isLoadingTinymceApiKey || !tinymceApiKey) return <Spinner />
 
-  const processKeyword = (keyword: string) =>
-    keyword
-      .replace(/&nbsp;/g, '')
-      .trim()
-      .toLowerCase()
+  const initialHtml = `<h1>This is a sample header</h1> You can add {{keywords}} enclosed in {{curly}} braces`
 
   return (
     <TinymceEditor
       apiKey={tinymceApiKey}
-      initialValue={`<h1>This is a sample header</h1> You can add <span style="background-color: lightgray">{{keywords}}</span> enclosed in <span style="background-color: lightgray">{{curly}}</span> braces`}
+      initialValue={html || initialHtml}
       init={{
-        plugins: 'image code table help link powerpaste preview',
+        plugins: 'image code table help link',
         height: '100%',
         toolbar:
-          'undo redo | bold italic underline | blocks fontfamily fontsizeinput | link image table | preview',
-        setup: (editor) => {
-          editor.addCommand('highlight-brace-core', () => {
-            const keyword = processKeyword(editor.selection.getContent())
-            TEMPLATE_KEYWORD_CHAR_REGEX.test(keyword)
-              ? editor.selection.setContent(
-                  `<span style="background-color: lightgray">{{${keyword}}}</span>`,
-                )
-              : editor.selection.setContent(
-                  `{{${editor.selection.getContent()}}}`,
-                )
-          })
-          editor.addCommand('highlight-brace-add-1', () => {
-            const keyword = processKeyword(editor.selection.getContent())
-            TEMPLATE_KEYWORD_CHAR_REGEX.test(keyword)
-              ? editor.selection.setContent(
-                  `{<span style="background-color: lightgray">{{${keyword}}}</span>}`,
-                )
-              : editor.selection.setContent(
-                  `{{{${editor.selection.getContent()}}}}`,
-                )
-          })
-        },
-        text_patterns: [
-          {
-            start: '{{{',
-            end: '}}}',
-            cmd: 'highlight-brace-add-1',
-          },
-          {
-            start: '{{',
-            end: '}}',
-            cmd: 'highlight-brace-core',
-          },
-        ],
+          'undo redo | bold italic underline | blocks fontfamily fontsizeinput | link image table',
       }}
       disabled={isDisabled}
-      onEditorChange={(content) => onContentChange(content)}
+      onEditorChange={onContentChange}
     />
   )
 }

--- a/frontend/src/features/editor/components/TemplateEditor.tsx
+++ b/frontend/src/features/editor/components/TemplateEditor.tsx
@@ -17,7 +17,11 @@ export const TemplateEditor = ({
   const { tinymceApiKey, isLoadingTinymceApiKey } = useTinymceApiKey()
   if (isLoadingTinymceApiKey || !tinymceApiKey) return <Spinner />
 
-  const processKeyword = (keyword: string) => keyword.toLowerCase().trim()
+  const processKeyword = (keyword: string) =>
+    keyword
+      .replace(/&nbsp;/g, '')
+      .trim()
+      .toLowerCase()
 
   return (
     <TinymceEditor

--- a/frontend/src/features/editor/components/TemplateEditor.tsx
+++ b/frontend/src/features/editor/components/TemplateEditor.tsx
@@ -15,62 +15,51 @@ export const TemplateEditor = ({
   isDisabled = false,
 }: TemplateEditorProps): JSX.Element => {
   const { tinymceApiKey, isLoadingTinymceApiKey } = useTinymceApiKey()
+  if (isLoadingTinymceApiKey || !tinymceApiKey) return <Spinner />
 
-  if (isLoadingTinymceApiKey || !tinymceApiKey) {
-    return <Spinner />
-  }
+  const processKeyword = (keyword: string) => keyword.toLowerCase().trim()
 
   return (
     <TinymceEditor
       apiKey={tinymceApiKey}
       initialValue={`<h1>This is a sample header</h1> You can add <span style="background-color: lightgray">{{keywords}}</span> enclosed in <span style="background-color: lightgray">{{curly}}</span> braces`}
       init={{
-        plugins: 'image code table help link',
+        plugins: 'image code table help link powerpaste preview',
         height: '100%',
         toolbar:
-          'undo redo | bold italic underline | blocks fontfamily fontsizeinput | link image table',
+          'undo redo | bold italic underline | blocks fontfamily fontsizeinput | link image table | preview',
         setup: (editor) => {
-          editor.addCommand('highlight-core', function () {
-            const lowerCaseValue = editor.selection
-              .getContent()
-              .toLowerCase()
-              .trim()
-
-            if (TEMPLATE_KEYWORD_CHAR_REGEX.test(lowerCaseValue))
-              editor.selection.setContent(
-                `<span style="background-color: lightgray">{{${lowerCaseValue}}}</span>`,
-              )
-            else
-              editor.selection.setContent(
-                `{{${editor.selection.getContent()}}}`,
-              )
+          editor.addCommand('highlight-brace-core', () => {
+            const keyword = processKeyword(editor.selection.getContent())
+            TEMPLATE_KEYWORD_CHAR_REGEX.test(keyword)
+              ? editor.selection.setContent(
+                  `<span style="background-color: lightgray">{{${keyword}}}</span>`,
+                )
+              : editor.selection.setContent(
+                  `{{${editor.selection.getContent()}}}`,
+                )
           })
-          editor.addCommand('highlight-add-1', function () {
-            const lowerCaseValue = editor.selection
-              .getContent()
-              .toLowerCase()
-              .trim()
-
-            if (TEMPLATE_KEYWORD_CHAR_REGEX.test(lowerCaseValue))
-              editor.selection.setContent(
-                `{<span style="background-color: lightgray">{{${lowerCaseValue}}}</span>}`,
-              )
-            else
-              editor.selection.setContent(
-                `{{{${editor.selection.getContent()}}}}`,
-              )
+          editor.addCommand('highlight-brace-add-1', () => {
+            const keyword = processKeyword(editor.selection.getContent())
+            TEMPLATE_KEYWORD_CHAR_REGEX.test(keyword)
+              ? editor.selection.setContent(
+                  `{<span style="background-color: lightgray">{{${keyword}}}</span>}`,
+                )
+              : editor.selection.setContent(
+                  `{{{${editor.selection.getContent()}}}}`,
+                )
           })
         },
         text_patterns: [
           {
             start: '{{{',
             end: '}}}',
-            cmd: 'highlight-add-1',
+            cmd: 'highlight-brace-add-1',
           },
           {
             start: '{{',
             end: '}}',
-            cmd: 'highlight-core',
+            cmd: 'highlight-brace-core',
           },
         ],
       }}

--- a/frontend/src/features/editor/components/TemplateEditor.tsx
+++ b/frontend/src/features/editor/components/TemplateEditor.tsx
@@ -1,40 +1,81 @@
 import { Spinner } from '@chakra-ui/react'
 import { Editor as TinymceEditor } from '@tinymce/tinymce-react'
 
+import { TEMPLATE_KEYWORD_CHAR_REGEX } from '~shared/constants/regex'
+
 import { useTinymceApiKey } from '../hooks/tinymce.hooks'
 
 interface TemplateEditorProps {
-  html: string | undefined
-  onContentChange?: React.Dispatch<React.SetStateAction<string>>
+  onContentChange: React.Dispatch<React.SetStateAction<string>>
   isDisabled?: boolean
 }
 
 export const TemplateEditor = ({
-  html,
   onContentChange,
   isDisabled = false,
 }: TemplateEditorProps): JSX.Element => {
   const { tinymceApiKey, isLoadingTinymceApiKey } = useTinymceApiKey()
-  if (isLoadingTinymceApiKey || !html || !tinymceApiKey) {
-    return <Spinner />
-  }
 
-  const handleEditorChange = (content: string) => {
-    if (onContentChange) onContentChange(content)
+  if (isLoadingTinymceApiKey || !tinymceApiKey) {
+    return <Spinner />
   }
 
   return (
     <TinymceEditor
       apiKey={tinymceApiKey}
-      initialValue={html}
+      initialValue={`<h1>This is a sample header</h1> You can add <span style="background-color: lightgray">{{keywords}}</span> enclosed in <span style="background-color: lightgray">{{curly}}</span> braces`}
       init={{
         plugins: 'image code table help link',
         height: '100%',
         toolbar:
           'undo redo | bold italic underline | blocks fontfamily fontsizeinput | link image table',
+        setup: (editor) => {
+          editor.addCommand('highlight-core', function () {
+            const lowerCaseValue = editor.selection
+              .getContent()
+              .toLowerCase()
+              .trim()
+
+            if (TEMPLATE_KEYWORD_CHAR_REGEX.test(lowerCaseValue))
+              editor.selection.setContent(
+                `<span style="background-color: lightgray">{{${lowerCaseValue}}}</span>`,
+              )
+            else
+              editor.selection.setContent(
+                `{{${editor.selection.getContent()}}}`,
+              )
+          })
+          editor.addCommand('highlight-add-1', function () {
+            const lowerCaseValue = editor.selection
+              .getContent()
+              .toLowerCase()
+              .trim()
+
+            if (TEMPLATE_KEYWORD_CHAR_REGEX.test(lowerCaseValue))
+              editor.selection.setContent(
+                `{<span style="background-color: lightgray">{{${lowerCaseValue}}}</span>}`,
+              )
+            else
+              editor.selection.setContent(
+                `{{{${editor.selection.getContent()}}}}`,
+              )
+          })
+        },
+        text_patterns: [
+          {
+            start: '{{{',
+            end: '}}}',
+            cmd: 'highlight-add-1',
+          },
+          {
+            start: '{{',
+            end: '}}',
+            cmd: 'highlight-core',
+          },
+        ],
       }}
       disabled={isDisabled}
-      onEditorChange={handleEditorChange}
+      onEditorChange={(content) => onContentChange(content)}
     />
   )
 }

--- a/shared/src/constants/regex.ts
+++ b/shared/src/constants/regex.ts
@@ -1,3 +1,1 @@
-export const TEMPLATE_KEYWORD_REGEX = /{{(?:([a-z0-9_]+)}})/g
-export const TEMPLATE_KEYWORD_DELIMITER_REGEX = /{{([^{}]+)}}/g
-export const TEMPLATE_KEYWORD_CHAR_REGEX = /^[a-z0-9_]+$/
+export const ACCEPTED_TEMPLATE_FIELDS_REGEX = /{{( *[a-zA-Z0-9_]+ *)}}/g

--- a/shared/src/constants/regex.ts
+++ b/shared/src/constants/regex.ts
@@ -1,2 +1,3 @@
-export const TEMPLATE_KEYWORD_REGEX = /\{\{([^{}]+)\}\}/g
+export const TEMPLATE_KEYWORD_REGEX = /{{+(?:([a-z0-9_]+)}}+)/g
+export const TEMPLATE_KEYWORD_DELIMITER_REGEX = /\{\{([^{}]+)\}\}/g
 export const TEMPLATE_KEYWORD_CHAR_REGEX = /^[a-z0-9_]+$/

--- a/shared/src/constants/regex.ts
+++ b/shared/src/constants/regex.ts
@@ -1,1 +1,2 @@
 export const TEMPLATE_KEYWORD_REGEX = /\{\{([^{}]+)\}\}/g
+export const TEMPLATE_KEYWORD_CHAR_REGEX = /^[a-z0-9_]+$/

--- a/shared/src/constants/regex.ts
+++ b/shared/src/constants/regex.ts
@@ -1,3 +1,3 @@
-export const TEMPLATE_KEYWORD_REGEX = /{{+(?:([a-z0-9_]+)}}+)/g
-export const TEMPLATE_KEYWORD_DELIMITER_REGEX = /\{\{([^{}]+)\}\}/g
+export const TEMPLATE_KEYWORD_REGEX = /{{(?:([a-z0-9_]+)}})/g
+export const TEMPLATE_KEYWORD_DELIMITER_REGEX = /{{([^{}]+)}}/g
 export const TEMPLATE_KEYWORD_CHAR_REGEX = /^[a-z0-9_]+$/

--- a/shared/src/dtos/templates.dto.ts
+++ b/shared/src/dtos/templates.dto.ts
@@ -1,9 +1,6 @@
-import { IsArray, IsDefined, IsString } from 'class-validator'
+import { IsDefined, IsString } from 'class-validator'
 
 export class CreateTemplateDto {
-  @IsDefined()
-  @IsArray()
-  fields: string[]
   @IsDefined()
   @IsString()
   html: string

--- a/shared/src/util/templates.ts
+++ b/shared/src/util/templates.ts
@@ -1,5 +1,6 @@
 import {
   TEMPLATE_KEYWORD_CHAR_REGEX,
+  TEMPLATE_KEYWORD_DELIMITER_REGEX,
   TEMPLATE_KEYWORD_REGEX,
 } from '../constants/regex'
 
@@ -10,32 +11,33 @@ export const deduplicateFields = (fields: string[]): string[] => [
   ...new Set(fields),
 ]
 
+export const setHtmlKeywordsToLowerCase = (html: string): string => {
+  return html.replace(
+    TEMPLATE_KEYWORD_DELIMITER_REGEX,
+    (match: string) => `${match.toLowerCase()}`,
+  )
+}
+
+export const getHtmlFields = (html: string) => {
+  const fields: string[] = []
+  let match: RegExpExecArray | null
+
+  while ((match = TEMPLATE_KEYWORD_REGEX.exec(html)) !== null)
+    if (
+      TEMPLATE_KEYWORD_CHAR_REGEX.test(match[1]) &&
+      !fields.includes(match[1])
+    )
+      fields.push(match[1])
+
+  return convertFieldsToLowerCase(fields)
+}
+
 export const isFieldsInvalid = (fields: string[]) => {
   const invalidFields: string[] = []
 
   fields.forEach((field) => {
     if (!TEMPLATE_KEYWORD_CHAR_REGEX.test(field)) invalidFields.push(field)
   })
-
-  return invalidFields.length > 0 ? invalidFields : false
-}
-
-export const setHtmlKeywordsToLowerCase = (html: string): string =>
-  html.replace(
-    TEMPLATE_KEYWORD_REGEX,
-    (match: string, keyword: string) => `{{${keyword.toLowerCase()}}}`,
-  )
-
-export const isHtmlKeywordsInvalid = (html: string) => {
-  const invalidFields: string[] = []
-  const matches = html.match(TEMPLATE_KEYWORD_REGEX)
-
-  if (matches) {
-    matches.forEach((match) => {
-      const key = match.slice(2, -2)
-      if (!TEMPLATE_KEYWORD_CHAR_REGEX.test(key)) invalidFields.push(match)
-    })
-  }
 
   return invalidFields.length > 0 ? invalidFields : false
 }

--- a/shared/src/util/templates.ts
+++ b/shared/src/util/templates.ts
@@ -11,12 +11,11 @@ export const deduplicateFields = (fields: string[]): string[] => [
   ...new Set(fields),
 ]
 
-export const setHtmlKeywordsToLowerCase = (html: string): string => {
-  return html.replace(
+export const setHtmlKeywordsToLowerCase = (html: string): string =>
+  html.replace(
     TEMPLATE_KEYWORD_DELIMITER_REGEX,
     (match: string) => `${match.toLowerCase()}`,
   )
-}
 
 export const getHtmlFields = (html: string) => {
   const fields: string[] = []

--- a/shared/src/util/templates.ts
+++ b/shared/src/util/templates.ts
@@ -1,38 +1,18 @@
-import {
-  TEMPLATE_KEYWORD_CHAR_REGEX,
-  TEMPLATE_KEYWORD_DELIMITER_REGEX,
-  TEMPLATE_KEYWORD_REGEX,
-} from '../constants/regex'
+import { ACCEPTED_TEMPLATE_FIELDS_REGEX } from '../constants/regex'
 
-export const convertFieldsToLowerCase = (fields: string[]): string[] =>
-  fields.map((field: string) => field.toLowerCase())
-
-export const deduplicateFields = (fields: string[]): string[] => [
-  ...new Set(fields),
-]
-
-export const setHtmlKeywordsToLowerCase = (html: string): string =>
-  html.replace(
-    TEMPLATE_KEYWORD_DELIMITER_REGEX,
-    (match: string) => `${match.toLowerCase()}`,
-  )
-
-export const getHtmlFields = (html: string) => {
+export const getTemplateFields = (html: string): string[] => {
+  // returns array of unique valid template fields
   const fields: string[] = []
   let match: RegExpExecArray | null
 
-  while ((match = TEMPLATE_KEYWORD_REGEX.exec(html)) !== null)
+  while ((match = ACCEPTED_TEMPLATE_FIELDS_REGEX.exec(html)) !== null) {
     if (!fields.includes(match[1])) fields.push(match[1])
-
-  return convertFieldsToLowerCase(fields)
+  }
+  return fields
 }
 
-export const isFieldsInvalid = (fields: string[]) => {
-  const invalidFields: string[] = []
-
-  fields.forEach((field) => {
-    if (!TEMPLATE_KEYWORD_CHAR_REGEX.test(field)) invalidFields.push(field)
-  })
-
-  return invalidFields.length > 0 ? invalidFields : false
-}
+export const parseTemplateField = (field: string): string =>
+  field
+    .replace(/&nbsp;/g, '')
+    .trim()
+    .toLowerCase()

--- a/shared/src/util/templates.ts
+++ b/shared/src/util/templates.ts
@@ -23,11 +23,7 @@ export const getHtmlFields = (html: string) => {
   let match: RegExpExecArray | null
 
   while ((match = TEMPLATE_KEYWORD_REGEX.exec(html)) !== null)
-    if (
-      TEMPLATE_KEYWORD_CHAR_REGEX.test(match[1]) &&
-      !fields.includes(match[1])
-    )
-      fields.push(match[1])
+    if (!fields.includes(match[1])) fields.push(match[1])
 
   return convertFieldsToLowerCase(fields)
 }

--- a/shared/src/util/templates.ts
+++ b/shared/src/util/templates.ts
@@ -1,4 +1,7 @@
-import { TEMPLATE_KEYWORD_REGEX } from '../constants/regex'
+import {
+  TEMPLATE_KEYWORD_CHAR_REGEX,
+  TEMPLATE_KEYWORD_REGEX,
+} from '../constants/regex'
 
 export const convertFieldsToLowerCase = (fields: string[]): string[] =>
   fields.map((field: string) => field.toLowerCase())
@@ -7,8 +10,32 @@ export const deduplicateFields = (fields: string[]): string[] => [
   ...new Set(fields),
 ]
 
+export const isFieldsInvalid = (fields: string[]) => {
+  const invalidFields: string[] = []
+
+  fields.forEach((field) => {
+    if (!TEMPLATE_KEYWORD_CHAR_REGEX.test(field)) invalidFields.push(field)
+  })
+
+  return invalidFields.length > 0 ? invalidFields : false
+}
+
 export const setHtmlKeywordsToLowerCase = (html: string): string =>
   html.replace(
     TEMPLATE_KEYWORD_REGEX,
     (match: string, keyword: string) => `{{${keyword.toLowerCase()}}}`,
   )
+
+export const isHtmlKeywordsInvalid = (html: string) => {
+  const invalidFields: string[] = []
+  const matches = html.match(TEMPLATE_KEYWORD_REGEX)
+
+  if (matches) {
+    matches.forEach((match) => {
+      const key = match.slice(2, -2)
+      if (!TEMPLATE_KEYWORD_CHAR_REGEX.test(key)) invalidFields.push(match)
+    })
+  }
+
+  return invalidFields.length > 0 ? invalidFields : false
+}


### PR DESCRIPTION
## Context

This PR handles the different instances of valid and invalid keywords when creating a new template and adds dynamic highlighting of keywords into the editor to whenever a user defines a keyword, as well as implementing the relevant field and html validations during backend template creation.

Closes [Template variable handling](https://www.notion.so/opengov/2ccadbea5c734aa09614b4ca8cc7177e?v=76cff9fca57b496f857c990e2639af2f&p=a0c8c5b621304863ae40a7be09acfa11&pm=s)

## Approach

- Shared
  - Updated constant `TEMPLATE_KEYWORD_REGEX` to match against keywords with two or more braces, containing lowercase alphanumerics and underscore only
 
  - Added constant `TEMPLATE_KEYWORD_CHAR_REGEX` to accept only lowercase alphanumerics and underscore keywords

  - Added constant `TEMPLATE_KEYWORD_DELIMITER_REGEX` to match against any potential keywords wrapped with two braces (used when parsing html to convert keywords to lowercase)
 
  - Added `getHtmlFields` function that accepts a html string and checks for and return valid keyword that matches `TEMPLATE_KEYWORD_REGEX` 
 
  - Added `isFieldsInvalid` function that accepts an array of fields and checks for and return any invalid fields that doesn't match the `TEMPLATE_KEYWORD_CHAR_REGEX` 


- Frontend
  - Added plugins:
    - `powerpaste` to automatically clean up content from Microsoft Word, Microsoft Excel, and HTML sources to ensure clean, compliant content
    - `preview` to allow preview within the editor
  - Utilised the TinyMCE's `text-patterns` option to configure patterns to be matched as keywords 
    - Added inline patterns to handle double and triple braces

  - Utilised TinyMCE's `setup` option to specify a callback function to define custom commands that is called whenever a text pattern is matched
    - When matched, process the matched value to lowercase and trim
    - If matched value's pattern matches `TEMPLATE_KEYWORD_CHAR_REGEX` then highlights the processed value using  a `span` element, else retain its original formatting
    
  - Added `stripSpanTags` function to strip the `<span>` elements in the html string that was used to highlight keywords in the live editor before extracting keyword fields and creating a new template

  - Updated `fields` extraction logic during template creation to use the shared `getHtmlFields` function instead

- Backend
  - Updated `TemplatesParsingService` to check for invalid `html` and `fields` when called, and throws a `BadRequestException` detailing the invalid fields respectively


## Before & After Screenshots

**BEFORE**:

https://github.com/opengovsg/letters/assets/119388168/5ba7a318-a384-4a04-b28f-9eb9f87b7262

**AFTER**:

**Create**

https://github.com/opengovsg/letters/assets/119388168/c21be860-3242-4004-b149-db0efed51c50

**Issue**

https://github.com/opengovsg/letters/assets/119388168/71f66837-ce1b-4fef-b494-247d9659e065


