### PR TITLE
fix: fix zoom on hover and border radius of template card

### DIFF
--- a/frontend/src/features/dashboard/TemplatesPage.tsx
+++ b/frontend/src/features/dashboard/TemplatesPage.tsx
@@ -12,8 +12,9 @@ export const TemplatesPage = (): JSX.Element => {
 
   return (
     <VStack alignItems="left" spacing="0px">
-      <VStack pt={2.5} pl={8} spacing={8} align={'center'}>
+      <VStack pt={2.5} align={'center'}>
         <Button
+          marginLeft={8}
           alignSelf="start"
           leftIcon={<PlusCircle />}
           onClick={() => navigate(`/admin/${routes.admin.create}`)}

--- a/frontend/src/features/dashboard/components/TemplateCard.tsx
+++ b/frontend/src/features/dashboard/components/TemplateCard.tsx
@@ -1,12 +1,4 @@
-import {
-  Button,
-  Card,
-  CardHeader,
-  Flex,
-  Heading,
-  Image,
-  Text,
-} from '@chakra-ui/react'
+import { Card, CardHeader, Flex, Heading, Image, Text } from '@chakra-ui/react'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -43,7 +35,12 @@ export const TemplateCard = (templateCardProps: TemplateCardProps) => {
       onMouseLeave={handleMouseHover}
       onClick={() => navigate(`${templateCardProps.id}/issue`)}
     >
-      <Flex justifyContent="center" background="#F8F9F9" paddingTop={5}>
+      <Flex
+        borderTopRadius={'inherit'}
+        justifyContent="center"
+        background="#F8F9F9"
+        paddingTop={5}
+      >
         <Image
           src={templateCardProps.thumbnailS3Path}
           width={170}

--- a/frontend/src/features/dashboard/components/TemplatesBody.tsx
+++ b/frontend/src/features/dashboard/components/TemplatesBody.tsx
@@ -7,7 +7,7 @@ export const TemplatesBody = () => {
   const { templates, isTemplatesLoading } = useGetTemplates()
   return (
     <Flex flexDir="row" flex="1">
-      <Wrap flex="1" spacing="30px">
+      <Wrap flex="1" spacing="30px" padding={8}>
         {!isTemplatesLoading && templates.length > 0 ? (
           templates.map((template, index) => (
             <WrapItem key={index}>


### PR DESCRIPTION
## Context

- The zoom animation of the template card was broken as that card was cut off on any side of the parent container when zoomed in
- Th shadow on any side touching the parent container was cut off.
- The top border radius of the card was not correct.

This PR fixes these issues.

## Before & After Screenshots

**BEFORE**:
![Screen Recording 2023-06-15 at 7 12 11 PM](https://github.com/opengovsg/letters/assets/12240377/935b2daa-3c43-4b59-bdda-e9c2f29da65a)

**AFTER**:
![Screen Recording 2023-06-15 at 7 13 07 PM](https://github.com/opengovsg/letters/assets/12240377/6f264ed4-2046-400e-b09b-3a591cec0c6d)

