### PR TITLE
chore: add read receipts for letters 

### DIFF
--- a/backend/src/config/config.schema.ts
+++ b/backend/src/config/config.schema.ts
@@ -242,6 +242,6 @@ export const schema: Schema<ConfigSchema> = {
     doc: 'The API key used for Tinymce',
     env: 'TINYMCE_API_KEY',
     format: String,
-    default: '', // defaults to empty string, which will disable TinyMCE
+    default: 'abc', // defaults to empty string, which will disable TinyMCE
   },
 }

--- a/backend/src/core/dto-mappers/letter.dto-mapper.ts
+++ b/backend/src/core/dto-mappers/letter.dto-mapper.ts
@@ -12,6 +12,7 @@ export const mapLetterToPublicDto = (letter: Letter): GetLetterPublicDto => {
     publicId: letter.publicId,
     createdAt: letter.createdAt,
     issuedLetter: letter.issuedLetter,
+    firstReadAt: letter.firstReadAt,
   }
 }
 
@@ -20,6 +21,7 @@ export const mapLetterToDto = (letter: Letter): GetLetterDto => {
     templateName: letter.template.name,
     publicId: letter.publicId,
     createdAt: letter.createdAt.toDateString(),
+    firstReadAt: letter.firstReadAt?.toDateString(),
     isPasswordProtected: letter.isPasswordProtected,
     issuedLetter: letter.issuedLetter,
   }

--- a/backend/src/database/entities/letter.entity.ts
+++ b/backend/src/database/entities/letter.entity.ts
@@ -48,4 +48,7 @@ export class Letter {
 
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date
+
+  @Column({ type: 'timestamptz', nullable: true, default: null })
+  firstReadAt: Date
 }

--- a/backend/src/database/migrations/1687250665550-add-first-read-at-column-to-letter.ts
+++ b/backend/src/database/migrations/1687250665550-add-first-read-at-column-to-letter.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class addFirstReadAtColumnToLetter1687250665550
+  implements MigrationInterface
+{
+  name = 'addFirstReadAtColumnToLetter1687250665550'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "letters" ADD "firstReadAt" TIMESTAMP WITH TIME ZONE`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "letters" DROP COLUMN "firstReadAt"`)
+  }
+}

--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -140,6 +140,18 @@ export class LettersService {
     return letter
   }
 
+  async recordFirstReadAt(letter: Letter) {
+    // If time that letter has been retrieved has already been recorded, then do nothing
+    if (letter.firstReadAt) return
+
+    const updatedLetter = {
+      ...letter,
+      firstReadAt: new Date().toISOString(),
+    }
+
+    await this.repository.save(updatedLetter)
+  }
+
   findOne(id: number) {
     return `This action returns a #${id} letter`
   }

--- a/backend/src/public/public.controller.ts
+++ b/backend/src/public/public.controller.ts
@@ -15,6 +15,7 @@ export class PublicController {
     const letter = await this.lettersService.findOneByPublicId(publicId)
     if (!letter) throw new NotFoundException('letter not found')
 
+    await this.lettersService.recordFirstReadAt(letter)
     return mapLetterToPublicDto(letter)
   }
 }

--- a/frontend/src/features/dashboard/IssuedLettersPage.tsx
+++ b/frontend/src/features/dashboard/IssuedLettersPage.tsx
@@ -8,7 +8,7 @@ import {
   useDisclosure,
   VStack,
 } from '@chakra-ui/react'
-import { Link, Pagination } from '@opengovsg/design-system-react'
+import { Badge, Link, Pagination } from '@opengovsg/design-system-react'
 import { useState } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 
@@ -51,6 +51,7 @@ export const IssuedLettersPage = (): JSX.Element => {
             <Tr backgroundColor="interaction.main-subtle.default">
               <HeaderCell>Letter link</HeaderCell>
               <HeaderCell>Issued on</HeaderCell>
+              <HeaderCell>Read Receipt</HeaderCell>
               <HeaderCell>Template used</HeaderCell>
             </Tr>
             {letters &&
@@ -78,6 +79,15 @@ export const IssuedLettersPage = (): JSX.Element => {
                     </Link>
                   </Td>
                   <Td>{letter.createdAt}</Td>
+                  <Td>
+                    {letter.firstReadAt ? (
+                      <Badge variant="subtle">Read</Badge>
+                    ) : (
+                      <Badge variant="subtle" colorScheme="grey">
+                        Unread
+                      </Badge>
+                    )}
+                  </Td>
                   <Td>{letter.templateName}</Td>
                 </Box>
               ))}

--- a/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
+++ b/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
@@ -118,6 +118,10 @@ export const IssuedLetterDrawer = ({
                 }
               />
               <GridItem
+                heading="Read Reciept"
+                content={<Text>{letter.firstReadAt ?? 'Unread'}</Text>}
+              />
+              <GridItem
                 heading="Issued on"
                 content={<Text>{letter.createdAt}</Text>}
               />

--- a/shared/src/dtos/letters.dto.ts
+++ b/shared/src/dtos/letters.dto.ts
@@ -44,12 +44,14 @@ export class GetLetterPublicDto {
   publicId: string
   issuedLetter: string
   createdAt: Date
+  firstReadAt: Date
 }
 
 export class GetLetterDto {
   templateName: string
   publicId: string
   createdAt: string
+  firstReadAt: string
   issuedLetter: string
   isPasswordProtected: boolean
 }


### PR DESCRIPTION
## Context

_Why does this PR exist? What problem are you trying to solve? What issue does this close?_

This PR adds the read receipts feature for letters after they are issued. Whenever the link is accessed, the read receipt will be marked as read, both in the table of issued letters and the additional information displayed in the drawer.  


Closes [add read receipts](https://www.notion.so/opengov/2ccadbea5c734aa09614b4ca8cc7177e?v=76cff9fca57b496f857c990e2639af2f&p=4f40e879c1e1428cb301eb5465a25a79&pm=s)

## Approach

_How did you solve the problem?_

Described in the notion doc above. 
We added a new column in letters table for recording the `firstReadAt` timestamp 
Based on the `firstReadAt` timestamp information we display, whether the letter has been read or not (will be nonnull if the  letter has been read).

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
[insert screenshot here]
<img width="1512" alt="Screenshot 2023-06-21 at 1 21 41 PM" src="https://github.com/opengovsg/letters/assets/25703976/4894e5d5-870c-4d89-8e55-c035c1f2863f">


**AFTER**:
Screen recording (and some sample screenshots) of the end to end flow:

https://github.com/opengovsg/letters/assets/25703976/e0034bef-e029-47eb-8ba1-5f686bf46d3c

<img width="1192" alt="Screenshot 2023-06-21 at 1 19 15 PM" src="https://github.com/opengovsg/letters/assets/25703976/ae33fd8a-af39-45ff-897e-0540d00409df">
<img width="1512" alt="Screenshot 2023-06-21 at 1 19 26 PM" src="https://github.com/opengovsg/letters/assets/25703976/460fb50d-59c4-4678-9e7e-b7accff7a11c">




