### PR TITLE
fix: do not rerender when password is entered

### DIFF
--- a/frontend/src/features/public/components/PasswordProtectedView.tsx
+++ b/frontend/src/features/public/components/PasswordProtectedView.tsx
@@ -24,6 +24,23 @@ interface PasswordProtectedViewProps {
   isLetterLoading: boolean
 }
 
+const NonMobileSidebarGridArea: FC<PropsWithChildren> = ({ children }) => {
+  return GenericNonMobileSidebarGridArea({ children }, '3 / 7')
+}
+
+const PasswordGridArea: FC<PropsWithChildren> = ({ children }) => {
+  return AuthGridArea({ children }, '8 / 10')
+}
+
+const BaseGridLayout = (props: GridProps) => {
+  return (
+    <AppGrid
+      templateRows={{ md: 'auto 1fr auto', lg: '1fr auto' }}
+      {...props}
+    />
+  )
+}
+
 export const PasswordProtectedView = ({
   handleSubmit,
   error,
@@ -31,20 +48,6 @@ export const PasswordProtectedView = ({
   setPassword,
   isLetterLoading,
 }: PasswordProtectedViewProps): JSX.Element => {
-  const BaseGridLayout = (props: GridProps) => (
-    <AppGrid
-      templateRows={{ md: 'auto 1fr auto', lg: '1fr auto' }}
-      {...props}
-    />
-  )
-
-  const PasswordGridArea: FC<PropsWithChildren> = ({ children }) => {
-    return AuthGridArea({ children }, '8 / 10')
-  }
-
-  const NonMobileSidebarGridArea: FC<PropsWithChildren> = ({ children }) =>
-    GenericNonMobileSidebarGridArea({ children }, '3 / 7')
-
   return (
     <BaseGridLayout flex={1} bg="white" h="100%">
       <NonMobileSidebarGridArea>


### PR DESCRIPTION
## Context

Upon entering a password for password protected letters the component would re-render. This was causing focus issues on mobile keyboards.
This PR fixes that behaviour, to only update the input field value instead.

## Approach

Moving child components out of the component function to the top level of the file.
See issue and solution [here](https://stackoverflow.com/questions/42573017/in-react-es6-why-does-the-input-field-lose-focus-after-typing-a-character)


## Before & After Screenshots

**BEFORE**:

https://github.com/opengovsg/letters/assets/12240377/3c3fc9f7-d331-440c-a585-55cedd25ef17




**AFTER**:

https://github.com/opengovsg/letters/assets/12240377/0b97e282-7f1d-439a-a0e5-705cca22170a


