### PR TITLE
Feat/public letter route

### DIFF
--- a/backend/src/core/utils/generate-public-id.spec.ts
+++ b/backend/src/core/utils/generate-public-id.spec.ts
@@ -1,0 +1,28 @@
+import { PROTECTED_NAMESPACES } from '~shared/constants/protected-namespaces'
+
+import { generatePublicId } from './generate-public-id'
+
+describe('generatePublicId', () => {
+  test('should return a unique ID not present in PROTECTED_NAMESPACES', () => {
+    const id = generatePublicId()
+    expect(PROTECTED_NAMESPACES).not.toContain(id)
+  })
+
+  test('should regenerate ID if it matches a protected string', () => {
+    // Create a mock function that always returns a protected string
+    const mockGenerateId = jest
+      .fn()
+      .mockReturnValueOnce('api')
+      .mockReturnValue('abcdefghi')
+
+    // Replace the original generateId function with the mock function
+    const id = generatePublicId(mockGenerateId)
+
+    // Expect the mock generateId function to be called twice (once for the initial match and once for the regenerated ID)
+    expect(mockGenerateId).toHaveBeenCalledTimes(2)
+    // Expect the regenerated ID to be different from the protected string
+    expect(PROTECTED_NAMESPACES).not.toContain(id)
+    // Expect the output to be 'abcdefghi'
+    expect(id).toEqual('abcdefghi')
+  })
+})

--- a/backend/src/core/utils/generate-public-id.spec.ts
+++ b/backend/src/core/utils/generate-public-id.spec.ts
@@ -9,20 +9,15 @@ describe('generatePublicId', () => {
   })
 
   test('should regenerate ID if it matches a protected string', () => {
-    // Create a mock function that always returns a protected string
-    const mockGenerateId = jest
+    const mockGenerator = jest
       .fn()
       .mockReturnValueOnce('api')
       .mockReturnValue('abcdefghi')
 
-    // Replace the original generateId function with the mock function
-    const id = generatePublicId(mockGenerateId)
+    const id = generatePublicId(mockGenerator)
 
-    // Expect the mock generateId function to be called twice (once for the initial match and once for the regenerated ID)
-    expect(mockGenerateId).toHaveBeenCalledTimes(2)
-    // Expect the regenerated ID to be different from the protected string
+    expect(mockGenerator).toHaveBeenCalledTimes(2)
     expect(PROTECTED_NAMESPACES).not.toContain(id)
-    // Expect the output to be 'abcdefghi'
     expect(id).toEqual('abcdefghi')
   })
 })

--- a/backend/src/core/utils/generate-public-id.ts
+++ b/backend/src/core/utils/generate-public-id.ts
@@ -1,5 +1,7 @@
 import crypto from 'crypto'
 
+import { PROTECTED_NAMESPACES } from '~shared/constants/protected-namespaces'
+
 // A workaround to nanoid being incompatible with commonjs
 const random = (bytes: number) => crypto.randomBytes(bytes)
 const customRandom = (
@@ -30,4 +32,15 @@ const customAlphabet = (alphabet: string, size: number) =>
 const ALPHABET =
   '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
 const ID_LENGTH = 32
-export const generatePublicId = customAlphabet(ALPHABET, ID_LENGTH)
+
+export const generatePublicId = (
+  generator = customAlphabet(ALPHABET, ID_LENGTH),
+): string => {
+  let id = generator()
+  // if publicId is in protected name space, regenerate
+  while (PROTECTED_NAMESPACES.includes(id)) {
+    id = generator()
+  }
+
+  return id
+}

--- a/backend/src/database/entities/letter.entity.ts
+++ b/backend/src/database/entities/letter.entity.ts
@@ -6,7 +6,7 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm'
 
-import { generatePublicId } from '../../core/utils'
+import { generatePublicId } from '../../core/utils/generate-public-id'
 import { Batch } from './batch.entity'
 import { Template } from './template.entity'
 import { User } from './user.entity'

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -32,6 +32,10 @@ const router = createBrowserRouter([
         ),
         children: adminRoutes,
       },
+      {
+        path: '*',
+        element: <Navigate to={routes.admin.index} />,
+      },
     ],
   },
 ])

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -32,10 +32,6 @@ const router = createBrowserRouter([
         ),
         children: adminRoutes,
       },
-      {
-        path: '*',
-        element: <Navigate to={routes.admin.index} />,
-      },
     ],
   },
 ])

--- a/frontend/src/app/Redirect.tsx
+++ b/frontend/src/app/Redirect.tsx
@@ -1,0 +1,34 @@
+// Implementation taken from https://medium.com/@maoznir/redirect-component-for-react-router-v6-c3b4821ecce
+// Provides a Redirect component that handles dynamic segments in the router
+// Can be used when redirecting with dynamic segments e.g. 'users/:id' to
+// 'user/:id' as Navigate does not handle dynamic segments
+
+import React from 'react'
+import { Params, useParams } from 'react-router'
+import { RelativeRoutingType } from 'react-router/dist/lib/context'
+import { Navigate } from 'react-router-dom'
+
+export interface RedirectProps {
+  to: string
+  state?: any
+  relative?: RelativeRoutingType
+}
+
+const updateTo = (to: string, params: Readonly<Params<string>>) => {
+  const entries = Object.entries(params) as [string, string][]
+  let path = `${to}`
+
+  entries.forEach(([key, value]) => {
+    path = path.replace(`:${key}`, `${value}`)
+  })
+
+  return path
+}
+
+/**
+ * Wraps the <Navigate> component and replaces "/:<paramName>" with "/<paramValue"
+ */
+export const Redirect: React.FC<RedirectProps> = ({ to, ...rest }) => {
+  const params = useParams()
+  return <Navigate to={updateTo(to, params)} {...rest} replace />
+}

--- a/frontend/src/app/routes/public.routes.tsx
+++ b/frontend/src/app/routes/public.routes.tsx
@@ -6,13 +6,19 @@ import { LandingPage } from '~features/landing/LandingPage'
 import { ErrorPage } from '~features/public/ErrorPage'
 import { LetterPublicPage } from '~features/public/LetterPublicPage'
 
+import { Redirect } from '../Redirect'
+
 export const publicRoutes: RouteObject[] = [
   {
     index: true,
     element: <LandingPage />,
   },
   {
-    path: `${routes.public.letters}/:letterPublicId`,
+    path: `letters/:letterPublicId`,
+    element: <Redirect to="/:letterPublicId" />,
+  },
+  {
+    path: `:letterPublicId`,
     element: <PublicLayout />,
     children: [
       {

--- a/frontend/src/app/routes/public.routes.tsx
+++ b/frontend/src/app/routes/public.routes.tsx
@@ -1,4 +1,4 @@
-import { RouteObject } from 'react-router-dom'
+import { Navigate, RouteObject } from 'react-router-dom'
 
 import { PublicLayout } from '~/layouts/PublicLayout'
 import { routes } from '~constants/routes'
@@ -36,5 +36,9 @@ export const publicRoutes: RouteObject[] = [
         element: <ErrorPage />,
       },
     ],
+  },
+  {
+    path: '*',
+    element: <Navigate to={routes.public.error} />, // TODO: Differentiate between invalid letters link and invalid page?
   },
 ]

--- a/frontend/src/app/routes/public.routes.tsx
+++ b/frontend/src/app/routes/public.routes.tsx
@@ -39,6 +39,6 @@ export const publicRoutes: RouteObject[] = [
   },
   {
     path: '*',
-    element: <Navigate to={routes.public.error} />, // TODO: Differentiate between invalid letters link and invalid page?
+    element: <Navigate to={routes.public.error} />,
   },
 ]

--- a/frontend/src/app/routes/public.routes.tsx
+++ b/frontend/src/app/routes/public.routes.tsx
@@ -1,4 +1,4 @@
-import { Navigate, RouteObject } from 'react-router-dom'
+import { RouteObject } from 'react-router-dom'
 
 import { PublicLayout } from '~/layouts/PublicLayout'
 import { routes } from '~constants/routes'
@@ -36,9 +36,5 @@ export const publicRoutes: RouteObject[] = [
         element: <ErrorPage />,
       },
     ],
-  },
-  {
-    path: '*',
-    element: <Navigate to={routes.public.error} />, // TODO: Differentiate between invalid letters link and invalid page?
   },
 ]

--- a/frontend/src/features/dashboard/IssuedLettersPage.tsx
+++ b/frontend/src/features/dashboard/IssuedLettersPage.tsx
@@ -71,7 +71,7 @@ export const IssuedLettersPage = (): JSX.Element => {
                   <Td>
                     <Link
                       as={RouterLink}
-                      to={`/letters/${letter.publicId}`}
+                      to={`/${letter.publicId}`}
                       textDecoration="none"
                       textColor="default"
                     >

--- a/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
+++ b/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
@@ -90,11 +90,7 @@ export const IssuedLetterDrawer = ({
                 heading="Letter link"
                 content={
                   <HStack maxW="full" alignItems="center">
-                    <Link
-                      as={RouterLink}
-                      to={`/letters/${letter.publicId}`}
-                      maxW="80%"
-                    >
+                    <Link as={RouterLink} to={`/${letter.publicId}`} maxW="80%">
                       {letterPublicLink}
                     </Link>
                     <Box position="relative">

--- a/frontend/src/features/issue/BulkIssueDrawer/DownloadCsv.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/DownloadCsv.tsx
@@ -10,6 +10,7 @@ import {
 } from '~features/issue/hooks/templates.hooks'
 import { GetBulkLetterDto } from '~shared/dtos/letters.dto'
 import { jsonArrToCsv } from '~utils/csvUtils'
+import { getLetterPublicLink } from '~utils/linkUtils'
 import { pluraliseIfNeeded } from '~utils/stringUtils'
 
 interface DownloadCsvProps {
@@ -34,7 +35,7 @@ export const DownloadCsv = ({
       return {
         ...letterParams,
         'Date of Issue': createdAt,
-        'Letter Link': `${document.location.host}/letters/${publicId}`,
+        'Letter Link': `${getLetterPublicLink(publicId)}`,
       }
     })
     jsonArrToCsv(downloadCsvName, bulkLettersWithLink)

--- a/frontend/src/utils/linkUtils.ts
+++ b/frontend/src/utils/linkUtils.ts
@@ -1,3 +1,3 @@
 export const getLetterPublicLink = (publicId: string): string => {
-  return `${document.location.host}/letters/${publicId}`
+  return `${document.location.host}/${publicId}`
 }

--- a/shared/src/constants/protected-namespaces.ts
+++ b/shared/src/constants/protected-namespaces.ts
@@ -9,4 +9,5 @@ export const PROTECTED_NAMESPACES = [
   'terms-of-use',
   'privacy',
   'guide',
+  'not-found',
 ]

--- a/shared/src/constants/protected-namespaces.ts
+++ b/shared/src/constants/protected-namespaces.ts
@@ -1,0 +1,12 @@
+export const PROTECTED_NAMESPACES = [
+  'api',
+  'admin',
+  'error',
+  // the following are unused but protected for future-proofing
+  'contact-us',
+  'faq',
+  'who-we-are',
+  'terms-of-use',
+  'privacy',
+  'guide',
+]


### PR DESCRIPTION
## Context
We want to change our public letters route from `letters.gov.sg/letters/<id>` to `letters.gov.sg/<id>`, so that the public will be able to recognize our links more easily.

## Approach

- Routing
  - Set up frontend route for public letters at `letters.gov.sg/<id>`
  - Set up redirect to forward old route `letters.gov.sg/letters/<id>` to new route `letters.gov.sg/<id>`
  - Remove old catchall route redirects (`letters.gov.sg/*` used to redirect to `letters.gov.sg/error`)
- Update frontend links/ buttons to the letters
- Added logic to defend protected namespaces during public id generation

## Screenshots
<img width="1790" alt="Screenshot 2023-06-23 at 5 23 35 PM" src="https://github.com/opengovsg/letters/assets/39231249/f4af2f93-685e-4286-8278-aff95d0dd555">

Redirection:
![gif](https://github.com/opengovsg/letters/assets/39231249/ba6bb54d-2e12-486c-9e35-93d51a81c27b)

