### PR TITLE
chore: add OTP_EXPIRY to letters ecs-task-definition

### DIFF
--- a/ecs-task-definition.json
+++ b/ecs-task-definition.json
@@ -53,6 +53,10 @@
           "valueFrom": "letters-<ENV>-otp-secret"
         },
         {
+          "name": "OTP_EXPIRY",
+          "valueFrom": "letters-<ENV>-otp-expiry"
+        },
+        {
           "name": "DD_API_KEY",
           "valueFrom": "letters-<ENV>-dd-api-key"
         },


### PR DESCRIPTION
We want to increase the default OTP expiration time. As we need to set the value via the Param Store, we need to add it to the `ecs-task-definition.json` file so that the value will be read from Param Store on deployment.