### PR TITLE
fix: remove empty lines from CSV processing

### DIFF
--- a/frontend/src/utils/csvUtils.ts
+++ b/frontend/src/utils/csvUtils.ts
@@ -48,6 +48,7 @@ export const csvToJsonArr = async (file: File): Promise<unknown[]> => {
       complete: (results) => {
         resolve(results.data)
       },
+      skipEmptyLines: true,
       error: (error) => {
         reject(error)
       },


### PR DESCRIPTION
## Context
We are trying to make the CSV uploads flow smoother, by eliminating blank lines from the CSV processing automatically instead of throwing error to the user that there is a blank line missing, which can sometimes be hard for the user to debug since, they are unable to recognise or "see" the missing lines on excel. 

Hence the code change involved here, is to remove the blank lines from CSV and also inform the user the number of blank lines that were ignored while their CSV file was processed.

Closes this [notion task](https://www.notion.so/opengov/Eng-Error-handling-for-CSV-uploads-47eb937d69274a03b4ae551446d16f4c)

## Approach

_How did you solve the problem?_
Make changes to the `papaparse` config to ignore the empty lines in the CSV.

We have implemented 1 in this PR.

## Before & After Screenshots

**BEFORE**:
## When a missing row was present 
--> error were being thrown
<img width="1512" alt="Screenshot 2023-06-23 at 6 28 29 PM" src="https://github.com/opengovsg/letters/assets/25703976/b5e07b9a-b23b-41f2-acf7-f82b0811c36d">


**AFTER**:
Tested for three different test cases:

## When the blank rows are ignored in the CSV

<img width="1920" alt="Screenshot 2023-06-26 at 3 48 00 PM" src="https://github.com/opengovsg/letters/assets/25703976/ed751feb-9f31-41f2-8663-6d2b6369089e">

## When blank rows are zero, no blank rows ignored
<img width="1512" alt="Screenshot 2023-06-23 at 6 11 06 PM" src="https://github.com/opengovsg/letters/assets/25703976/84c6d6a6-51f7-46d1-b205-68c2d4282b2e">

## When there's some usual error [regression testing]
<img width="1512" alt="Screenshot 2023-06-23 at 6 06 41 PM" src="https://github.com/opengovsg/letters/assets/25703976/95fc9d03-f8ec-4d62-bc6e-c38238e51d35">

