### PR TITLE
feat: Add QR Codes to Letters 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "react-helmet": "^6.1.0",
         "react-hook-form": "^7.43.8",
         "react-icons": "^4.8.0",
+        "react-qr-code": "^2.0.11",
         "react-router-dom": "^6.9.0",
         "wretch": "^2.5.1",
         "zod": "^3.21.4"
@@ -15446,6 +15447,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -15461,7 +15464,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -34611,6 +34616,11 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -35354,6 +35364,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.11.tgz",
+      "integrity": "sha512-P7mvVM5vk9NjGdHMt4Z0KWeeJYwRAtonHTghZT2r+AASinLUUKQ9wfsGH2lPKsT++gps7hXmaiMGRvwTDEL9OA==",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x",
+        "react-native-svg": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-svg": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -39829,6 +39857,7 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -52647,7 +52676,7 @@
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2",
         "react-element-to-jsx-string": "^14.3.4",
-        "react-refresh": "0.14.0",
+        "react-refresh": "^0.11.0",
         "read-pkg-up": "^7.0.1",
         "regenerator-runtime": "^0.13.7",
         "ts-dedent": "^2.0.0",
@@ -54850,15 +54879,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -54870,7 +54898,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -69412,6 +69442,11 @@
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "dev": true
     },
+    "qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+    },
     "qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -69956,6 +69991,15 @@
       "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
       "dev": true
     },
+    "react-qr-code": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.11.tgz",
+      "integrity": "sha512-P7mvVM5vk9NjGdHMt4Z0KWeeJYwRAtonHTghZT2r+AASinLUUKQ9wfsGH2lPKsT++gps7hXmaiMGRvwTDEL9OA==",
+      "requires": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      }
+    },
     "react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -70049,7 +70093,7 @@
         "prompts": "^2.4.2",
         "react-app-polyfill": "^3.0.0",
         "react-dev-utils": "^12.0.1",
-        "react-refresh": "0.14.0",
+        "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",
         "resolve-url-loader": "^4.0.0",
         "sass-loader": "^12.3.0",
@@ -73150,7 +73194,6 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.14",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
@@ -73178,6 +73221,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
           "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
           "dev": true,
+          "peer": true,
           "requires": {
             "nanoid": "^3.3.4",
             "picocolors": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.43.8",
     "react-icons": "^4.8.0",
+    "react-qr-code": "^2.0.11",
     "react-router-dom": "^6.9.0",
     "wretch": "^2.5.1",
     "zod": "^3.21.4"

--- a/frontend/src/features/editor/components/LetterQRCode.tsx
+++ b/frontend/src/features/editor/components/LetterQRCode.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 import QRCode from 'react-qr-code'
 
 interface LetterQRCodeProps {
@@ -9,28 +9,16 @@ export const LetterQRCode = ({
   qrCodeLinkValue,
 }: LetterQRCodeProps): JSX.Element => {
   return (
-    <div style={{ margin: 'auto', padding: '25px' }}>
-      <hr />
-      <Text>
-        This letter was retrieved from <b>{qrCodeLinkValue}</b>
-      </Text>
-      <div
+    <Box w="10%" h="10%">
+      <QRCode
+        size={12}
         style={{
-          height: '25%',
-          width: '25%',
-          margin: 'auto',
+          height: 'auto',
+          maxWidth: '100%',
+          width: '100%',
         }}
-      >
-        <QRCode
-          size={12}
-          style={{
-            height: 'auto',
-            maxWidth: '100%',
-            width: '100%',
-          }}
-          value={qrCodeLinkValue}
-        />
-      </div>
-    </div>
+        value={qrCodeLinkValue}
+      />
+    </Box>
   )
 }

--- a/frontend/src/features/editor/components/LetterQRCode.tsx
+++ b/frontend/src/features/editor/components/LetterQRCode.tsx
@@ -1,0 +1,36 @@
+import { Text } from '@chakra-ui/react'
+import QRCode from 'react-qr-code'
+
+interface LetterQRCodeProps {
+  qrCodeLinkValue: string
+}
+
+export const LetterQRCode = ({
+  qrCodeLinkValue,
+}: LetterQRCodeProps): JSX.Element => {
+  return (
+    <div style={{ margin: 'auto', padding: '25px' }}>
+      <hr />
+      <Text>
+        This letter was retrieved from <b>{qrCodeLinkValue}</b>
+      </Text>
+      <div
+        style={{
+          height: '25%',
+          width: '25%',
+          margin: 'auto',
+        }}
+      >
+        <QRCode
+          size={12}
+          style={{
+            height: 'auto',
+            maxWidth: '100%',
+            width: '100%',
+          }}
+          value={qrCodeLinkValue}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/editor/components/LetterViewer.tsx
+++ b/frontend/src/features/editor/components/LetterViewer.tsx
@@ -2,6 +2,8 @@ import { Box, BoxProps, Spinner, Text, VStack } from '@chakra-ui/react'
 
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
 
+import { LetterQRCode } from './LetterQRCode'
+
 interface LetterViewerProps extends BoxProps {
   letterPublicId?: string
   html: string | undefined
@@ -28,7 +30,15 @@ export const LetterViewer = ({
         borderColor="base.divider.medium"
         bg="white"
       >
-        <div dangerouslySetInnerHTML={{ __html: cleanHtml }}></div>
+        <>
+          <div dangerouslySetInnerHTML={{ __html: cleanHtml }}></div>
+
+          {letterPublicId && (
+            <LetterQRCode
+              qrCodeLinkValue={`${document.location.host}/letters/${letterPublicId}`}
+            />
+          )}
+        </>
       </Box>
       {letterPublicId && (
         <Box

--- a/frontend/src/features/editor/components/LetterViewer.tsx
+++ b/frontend/src/features/editor/components/LetterViewer.tsx
@@ -1,4 +1,4 @@
-import { Box, BoxProps, Spinner, Text, VStack } from '@chakra-ui/react'
+import { Box, BoxProps, HStack, Spinner, Text, VStack } from '@chakra-ui/react'
 
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
 
@@ -30,15 +30,7 @@ export const LetterViewer = ({
         borderColor="base.divider.medium"
         bg="white"
       >
-        <>
-          <div dangerouslySetInnerHTML={{ __html: cleanHtml }}></div>
-
-          {letterPublicId && (
-            <LetterQRCode
-              qrCodeLinkValue={`${document.location.host}/letters/${letterPublicId}`}
-            />
-          )}
-        </>
+        <div dangerouslySetInnerHTML={{ __html: cleanHtml }}></div>
       </Box>
       {letterPublicId && (
         <Box
@@ -50,15 +42,24 @@ export const LetterViewer = ({
           paddingX="28px"
           paddingY="0.75rem"
         >
-          <VStack spacing="0.25rem" alignItems="flex-start">
-            <Text textColor="black">
-              Letter ID: <b>{letterPublicId}</b>
-            </Text>
-            <Text textStyle="legal" textColor="grey.400">
-              This letter is generated using {document.location.host}. Forging
-              or morphing is a criminal offence.
-            </Text>
-          </VStack>
+          <HStack spacing="0.25rem" alignItems="flex-start">
+            <LetterQRCode
+              qrCodeLinkValue={`${document.location.host}/letters/${letterPublicId}`}
+            />
+            <VStack
+              spacing="0.25rem"
+              alignItems="flex-start"
+              style={{ margin: 'auto 10px' }}
+            >
+              <Text textColor="black" fontSize="sm">
+                Letter ID: <b>{letterPublicId}</b>
+              </Text>
+              <Text textStyle="legal" textColor="grey.400">
+                This letter is generated using {document.location.host}. Forging
+                or morphing is a criminal offence.
+              </Text>
+            </VStack>
+          </HStack>
         </Box>
       )}
     </VStack>


### PR DESCRIPTION
## Context

We are adding QR codes to letters, so that anyone can scan them and easily access the the link to the letter. 

Closes [this notion task](https://www.notion.so/opengov/Eng-Dynamic-QR-code-generation-ba96a9971dea42b48005f4f1862b5e46)

## Approach

We are using `react-qr-code` library for generating QR codes for links to different letters on client side. 
More details on the approach can be found [here](https://www.notion.so/opengov/20230624-QR-Code-Generation-for-Letters-b36e2699faff4a40b72279fb467b4c44)

**Features**:

- QR code will be shown when the letter is viewed and if there's a letter ID that exists. 
- No QR code is shown in preview [that's because we don't have a letter ID, although we can show a sample QR code for just preview purposes if required.]

## Before & After Screenshots

**BEFORE**:
Letter preview without the QR code:

<img width="1512" alt="Screenshot 2023-06-27 at 2 02 35 PM" src="https://github.com/opengovsg/letters/assets/25703976/8fbd81f3-8e94-41ee-bab6-55ef71a57495">


**AFTER**:

Flow of where and how the QR codes are seen after the new changes:


https://github.com/opengovsg/letters/assets/25703976/952959bb-94db-4e0b-b9ae-82d0660f436e


**New dev dependencies**:

`"react-qr-code": "^2.0.11"`

