### PR TITLE
Fix/read receipt update

### DIFF
--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -151,7 +151,10 @@ export class LettersService {
     return letter
   }
 
-  async recordFirstReadAt(letter: Letter) {
+  async recordFirstReadAt(id: number) {
+    const letter = await this.repository.findOneBy({ id })
+    if (!letter) throw new NotFoundException('Letter not found')
+
     // If time that letter has been retrieved has already been recorded, then do nothing
     if (letter.firstReadAt) return
 

--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -131,7 +131,10 @@ export class LettersService {
     })
   }
 
-  async findOneByPublicId(publicId: string, password?: string) {
+  async findOneByPublicId(
+    publicId: string,
+    password?: string,
+  ): Promise<Letter> {
     const letter = await this.repository.findOne({
       where: {
         publicId: publicId,
@@ -151,7 +154,7 @@ export class LettersService {
     return letter
   }
 
-  async recordFirstReadAt(id: number) {
+  async recordFirstReadAtById(id: number) {
     const letter = await this.repository.findOneBy({ id })
     if (!letter) throw new NotFoundException('Letter not found')
 

--- a/backend/src/public/public.controller.ts
+++ b/backend/src/public/public.controller.ts
@@ -26,7 +26,7 @@ export class PublicController {
     )
     if (!letter) throw new NotFoundException('Letter not found')
 
-    await this.lettersService.recordFirstReadAt(letter.id)
+    await this.lettersService.recordFirstReadAtById(letter.id)
     return mapLetterToPublicDto(letter)
   }
 }

--- a/backend/src/public/public.controller.ts
+++ b/backend/src/public/public.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
 } from '@nestjs/common'
 import { mapLetterToPublicDto } from 'core/dto-mappers/letter.dto-mapper'
+import { Letter } from 'database/entities'
 import { LettersService } from 'letters/letters.service'
 
 import { GetLetterPublicDto } from '~shared/dtos/letters.dto'
@@ -23,9 +24,9 @@ export class PublicController {
       publicId,
       password,
     )
-    if (!letter) throw new NotFoundException('letter not found')
+    if (!letter) throw new NotFoundException('Letter not found')
 
-    await this.lettersService.recordFirstReadAt(letter)
+    await this.lettersService.recordFirstReadAt(letter.id)
     return mapLetterToPublicDto(letter)
   }
 }


### PR DESCRIPTION
## Context

In the previous read receipt PR https://github.com/opengovsg/letters/pull/157, I introduced a bug for the password protected letters, which meant that users had only a single attempt to unlock their letters before it would be locked forever.

This was because in the public controller, we were decrypting the letter before recording the `firstReadAt`, but the `recordFirstReadAt` function used the decrypted letter to update the letter.

```
  @Get('letters/:publicId')
  async getLetterPublic(
    @Headers('password') password: string,
    @Param('publicId') publicId: string,
  ): Promise<GetLetterPublicDto> {
    const letter = await this.lettersService.findOneByPublicId(
      publicId,
      password,
    )
    if (!letter) throw new NotFoundException('letter not found')

    await this.lettersService.recordFirstReadAt(letter)
    return mapLetterToPublicDto(letter)
  }
```

## Approach

Instead of passing the letter object to `recordFirstReadAt`, we pass the letterId to `recordFirstReadAt`, and let the function handle the fetching of the object, validation whether the object exists, and the subsequent update.

```
  @Get('letters/:publicId')
  async getLetterPublic(
    @Headers('password') password: string,
    @Param('publicId') publicId: string,
  ): Promise<GetLetterPublicDto> {
    const letter = await this.lettersService.findOneByPublicId(
      publicId,
      password,
    )
    if (!letter) throw new NotFoundException('Letter not found')

    await this.lettersService.recordFirstReadAtById(letter.id)
    return mapLetterToPublicDto(letter)
  }
```

