### PR TITLE
fix: csv uploads error UI

### DIFF
--- a/frontend/src/features/issue/BulkIssueDrawer/UploadCsvErrorsTable.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/UploadCsvErrorsTable.tsx
@@ -42,6 +42,43 @@ export const UploadCsvErrorsTable = ({
     )
   }
 
+  const errorsByRow = uploadCsvErrors.reduce(
+    (errorGroup: Array<BulkLetterValidationResultError[]>, item) => {
+      if (errorGroup[item.id]) {
+        errorGroup[item.id].push(item)
+      } else {
+        errorGroup[item.id] = [item]
+      }
+      return errorGroup
+    },
+    new Array<BulkLetterValidationResultError[]>(uploadCsvErrors.length),
+  )
+
+  const errorTableRows = errorsByRow.map((errorData, index) => {
+    return (
+      <Tr key={JSON.stringify(index)}>
+        {/* We add 2 because the first row with data in the CSV is row 2, even though it has index 0 */}
+        <Td>{index + 2}</Td>
+        <Td>
+          {errorData.map((error, index) => {
+            return (
+              <Text key={index}>
+                {/* Add 1 because index starts from 0 actually */}
+                {index + 1}
+                {'. '}
+                {error.param}{' '}
+                {error.message ===
+                BulkLetterValidationResultErrorMessage.INVALID_ATTRIBUTE
+                  ? 'is not a valid attribute'
+                  : 'is missing'}
+              </Text>
+            )
+          })}
+        </Td>
+      </Tr>
+    )
+  })
+
   return (
     <Box padding={8}>
       <HStack>
@@ -65,23 +102,7 @@ export const UploadCsvErrorsTable = ({
             <HeaderCell>Row #</HeaderCell>
             <HeaderCell>Errors</HeaderCell>
           </Tr>
-          {uploadCsvErrors.map((error) => {
-            return (
-              // TODO: find a better key for the error
-              // TODO: group all errors of the same row number together. should this be done on the frontend or backend?
-              <Tr key={JSON.stringify(error)}>
-                {/* We add 2 because the first row with data in the CSV is row 2, even though it has index 0 */}
-                <Td>{error.id + 2}</Td>
-                <Td>
-                  {error.param}{' '}
-                  {error.message ===
-                  BulkLetterValidationResultErrorMessage.INVALID_ATTRIBUTE
-                    ? 'is not a valid attribute'
-                    : 'is missing'}
-                </Td>
-              </Tr>
-            )
-          })}
+          {errorTableRows}
         </Table>
       </TableContainer>
     </Box>


### PR DESCRIPTION
## Context

We are trying to improve the design for CSV uploads. In this PR specifically we will group the errors for each row together, so that's it's easier for users to process these errors. 

Closes this notion [task](https://www.notion.so/opengov/Eng-Error-handling-for-CSV-uploads-47eb937d69274a03b4ae551446d16f4c).

## Approach

Fixed the design. Did some front-end processing to group errors from the same row together using `reduce`.
Since we don't expect a ton of errors anyways (the scale of errors would be limited by the number of letters generated in one go), front-end processing would still make sense and should not be too heavy.

**Features**:
- Group related row errors together

## Before & After Screenshots

**BEFORE**:

<img width="1511" alt="Screenshot 2023-06-30 at 1 57 44 PM" src="https://github.com/opengovsg/letters/assets/25703976/0928251e-093e-4d90-a847-f8f2d6ffc5c9">


**AFTER**:

https://github.com/opengovsg/letters/assets/25703976/60edb725-85b1-47f3-88e7-2f70a41eca9c




