### PR TITLE
chore: [officers] add passwordInstructions flow

### DIFF
--- a/backend/src/batches/batches.service.ts
+++ b/backend/src/batches/batches.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { EntityManager, Repository } from 'typeorm'
 
@@ -22,6 +22,15 @@ export class BatchesService {
   ): Promise<Batch> {
     const batch = this.repository.create(createBatchDto)
     return await entityManager.save(batch)
+  }
+
+  async findOneByBatchId(id: number): Promise<Batch> {
+    const batch = await this.repository.findOneBy({
+      id,
+    })
+    if (!batch) throw new NotFoundException('Batch not found')
+
+    return batch
   }
 
   findAll() {

--- a/backend/src/database/entities/batch.entity.ts
+++ b/backend/src/database/entities/batch.entity.ts
@@ -27,6 +27,6 @@ export class Batch {
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date
 
-  @Column({ type: 'text', nullable: true, default: null })
+  @Column({ type: 'text', default: '' })
   passwordInstructions: string
 }

--- a/backend/src/database/entities/batch.entity.ts
+++ b/backend/src/database/entities/batch.entity.ts
@@ -26,4 +26,7 @@ export class Batch {
 
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date
+
+  @Column({ type: 'text', nullable: true, default: null })
+  passwordInstructions: string
 }

--- a/backend/src/database/migrations/1688119081079-add-password-instruction-to-batches.ts
+++ b/backend/src/database/migrations/1688119081079-add-password-instruction-to-batches.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class addPasswordInstructionToBatches1688119081079
+  implements MigrationInterface
+{
+  name = 'addPasswordInstructionToBatches1688119081079'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD "passwordInstructions" text`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batches" DROP COLUMN "passwordInstructions"`,
+    )
+  }
+}

--- a/backend/src/database/migrations/1688491822294-add-password-instructions-to-batches.ts
+++ b/backend/src/database/migrations/1688491822294-add-password-instructions-to-batches.ts
@@ -1,13 +1,13 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class addPasswordInstructionToBatches1688119081079
+export class addPasswordInstructionsToBatches1688491822294
   implements MigrationInterface
 {
-  name = 'addPasswordInstructionToBatches1688119081079'
+  name = 'addPasswordInstructionsToBatches1688491822294'
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "batches" ADD "passwordInstructions" text`,
+      `ALTER TABLE "batches" ADD "passwordInstructions" text NOT NULL DEFAULT ''`,
     )
   }
 

--- a/backend/src/letters/letters-validation.service.spec.ts
+++ b/backend/src/letters/letters-validation.service.spec.ts
@@ -12,8 +12,14 @@ describe('LettersValidationService', () => {
   describe('validate Passwords', () => {
     it('should not validate passwords if none are set', () => {
       const passwords = undefined
+      const passwordInstructions = undefined
 
-      const result = service.validateBulk([], [], passwords)
+      const result = service.validateBulk(
+        [],
+        [],
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(true)
       expect(result.message).toEqual('Validation Success')
@@ -28,8 +34,15 @@ describe('LettersValidationService', () => {
           field1: 'param1',
         },
       ]
+      const passwordInstructions =
+        'These are some instructions to unlock the letters'
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(false)
       expect(result.message).toEqual('Malformed bulk create object')
@@ -52,8 +65,15 @@ describe('LettersValidationService', () => {
           field1: 'param1',
         },
       ]
+      const passwordInstructions =
+        'These are some instructions to unlock the letters'
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(false)
       expect(result.message).toEqual('Malformed bulk create object')
@@ -77,8 +97,15 @@ describe('LettersValidationService', () => {
           field3: 'param3',
         },
       ]
+      const passwordInstructions =
+        'These are some instructions to unlock the letters'
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(false)
       expect(result.message).toEqual(
@@ -100,8 +127,76 @@ describe('LettersValidationService', () => {
           field1: 'param1',
         },
       ]
+      const passwordInstructions =
+        'These are some instructions to unlock the letters'
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.message).toEqual('Validation Success')
+      expect(result.errors).toBeUndefined()
+    })
+  })
+
+  describe('validate password instructions', () => {
+    it('should not validate if the password instructions are less than 10 characters', () => {
+      const passwords: string[] = ['hunter2', 'hunter2', 'hunter2']
+      const fields = ['field1']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+      ]
+      const passwordInstructions = 'They are'
+
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual(
+        'Password instructions need to have a minimum of 10 characters',
+      )
+      expect(result.errors).toBeUndefined()
+    })
+
+    it('should validate is the password instructions are more than 10 characters', () => {
+      const passwords: string[] = ['hunter2', 'hunter2', 'hunter2']
+      const fields = ['field1']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+      ]
+      const passwordInstructions =
+        'These are some instructions to unlock the letters'
+
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(true)
       expect(result.message).toEqual('Validation Success')
@@ -125,8 +220,15 @@ describe('LettersValidationService', () => {
           field3: 'param3',
         },
       ]
+      const passwordInstructions =
+        'These are some instructions to unlock the letters'
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(true)
       expect(result.message).toEqual('Validation Success')
@@ -143,8 +245,14 @@ describe('LettersValidationService', () => {
           'field not in template': 'param3',
         },
       ]
+      const passwordInstructions = undefined
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(false)
       expect(result.message).toEqual('Malformed bulk create object')
@@ -161,6 +269,7 @@ describe('LettersValidationService', () => {
   describe('validate template fields are in letterParams', () => {
     it('should succeed when all fields are present in params', () => {
       const passwords = undefined
+      const passwordInstructions = undefined
       const fields = ['field1', 'field2', 'field3']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -175,7 +284,12 @@ describe('LettersValidationService', () => {
         },
       ]
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(true)
       expect(result.message).toEqual('Validation Success')
@@ -184,6 +298,7 @@ describe('LettersValidationService', () => {
 
     it('should fail when a template field is not present in the params', () => {
       const passwords = undefined
+      const passwordInstructions = undefined
       const fields = ['field1', 'field2', 'field3']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -197,7 +312,12 @@ describe('LettersValidationService', () => {
         },
       ]
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(false)
       expect(result.message).toEqual('Malformed bulk create object')
@@ -208,6 +328,7 @@ describe('LettersValidationService', () => {
 
     it('should fail when a param field is empty', () => {
       const passwords = undefined
+      const passwordInstructions = undefined
       const fields = ['field1', 'field2', 'field3']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -222,7 +343,12 @@ describe('LettersValidationService', () => {
         },
       ]
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(false)
       expect(result.message).toEqual('Malformed bulk create object')
@@ -235,6 +361,8 @@ describe('LettersValidationService', () => {
   describe('validate Bulk', () => {
     it('should succeed when request data is valid', () => {
       const passwords: string[] = ['hunter2', 'hunter2']
+      const passwordInstructions =
+        'These are some password instructions to unlock the letter'
       const fields = ['field1', 'field2', 'field3']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -249,7 +377,12 @@ describe('LettersValidationService', () => {
         },
       ]
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(true)
       expect(result.message).toEqual('Validation Success')
@@ -258,6 +391,8 @@ describe('LettersValidationService', () => {
 
     it('should raise errors with correct ids and messages when request data is not valid', () => {
       const passwords: string[] = ['hunter2', '']
+      const passwordInstructions =
+        'These are some password instructions to unlock the letters'
       const fields = ['field1', 'field2', 'field3', 'field missing']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -272,7 +407,12 @@ describe('LettersValidationService', () => {
         },
       ]
 
-      const result = service.validateBulk(fields, letterParamMaps, passwords)
+      const result = service.validateBulk(
+        fields,
+        letterParamMaps,
+        passwords,
+        passwordInstructions,
+      )
 
       expect(result.success).toBe(false)
       expect(result.message).toEqual('Malformed bulk create object')

--- a/backend/src/letters/letters-validation.service.spec.ts
+++ b/backend/src/letters/letters-validation.service.spec.ts
@@ -174,7 +174,7 @@ describe('LettersValidationService', () => {
       expect(result.errors).toBeUndefined()
     })
 
-    it('should validate is the password instructions are more than 10 characters', () => {
+    it('should validate if the password instructions are more than 10 characters', () => {
       const passwords: string[] = ['hunter2', 'hunter2', 'hunter2']
       const fields = ['field1']
       const letterParamMaps: LetterParamMaps = [

--- a/backend/src/letters/letters-validation.service.ts
+++ b/backend/src/letters/letters-validation.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@nestjs/common'
 
-import { BULK_MAX_ROW_LENGTH } from '~shared/constants/letters'
+import {
+  BULK_MAX_ROW_LENGTH,
+  MIN_PASSWORD_INSTRUCTION_LENGTH,
+} from '~shared/constants/letters'
 import {
   BulkLetterValidationResultDto,
   BulkLetterValidationResultError,
@@ -14,6 +17,7 @@ export class LettersValidationService {
     fields: string[],
     letterParamMaps: LetterParamMaps,
     passwords: string[] | undefined,
+    passwordInstructions: string | undefined, // TODO: perform validation check
   ): BulkLetterValidationResultDto {
     if (letterParamMaps.length > BULK_MAX_ROW_LENGTH) {
       return {
@@ -26,6 +30,17 @@ export class LettersValidationService {
       return {
         success: false,
         message: 'Number of passwords does not match number of letters',
+      }
+    }
+
+    if (
+      passwordInstructions &&
+      passwordInstructions.length < MIN_PASSWORD_INSTRUCTION_LENGTH
+    ) {
+      return {
+        success: false,
+        message:
+          'Password instructions need to have a minimum of 10 characters',
       }
     }
 

--- a/backend/src/letters/letters-validation.service.ts
+++ b/backend/src/letters/letters-validation.service.ts
@@ -17,7 +17,7 @@ export class LettersValidationService {
     fields: string[],
     letterParamMaps: LetterParamMaps,
     passwords: string[] | undefined,
-    passwordInstructions: string | undefined, // TODO: perform validation check
+    passwordInstructions: string | undefined,
   ): BulkLetterValidationResultDto {
     if (letterParamMaps.length > BULK_MAX_ROW_LENGTH) {
       return {

--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -7,6 +7,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm'
 import { DataSource, EntityManager, Repository } from 'typeorm'
 
+import { PASSWORD_ERROR_MESSAGE } from '~shared/constants/letters'
 import { CreateBatchDto } from '~shared/dtos/batches.dto'
 import {
   CreateBulkLetterDto,
@@ -147,8 +148,18 @@ export class LettersService {
     if (!letter) throw new NotFoundException('Letter not found')
 
     if (letter.isPasswordProtected) {
+      // this is the case, where we show the screen for entering the password
+      // and the password instructions. So here we pass the password instructions
+      // to be displayed on frontend
       if (!password) {
-        throw new UnauthorizedException('No Password provided')
+        const letterBatch = await this.batchesService.findOneByBatchId(
+          letter.batchId,
+        )
+        throw new UnauthorizedException({
+          statusCode: 401,
+          message: PASSWORD_ERROR_MESSAGE,
+          passwordInstructions: letterBatch.passwordInstructions,
+        })
       }
 
       return this.lettersEncryptionService.decryptLetter(letter, password)

--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -55,7 +55,8 @@ export class LettersService {
     userId: number,
     createBulkLetterDto: CreateBulkLetterDto,
   ): Promise<Letter[]> {
-    const { templateId, letterParamMaps, passwords } = createBulkLetterDto
+    const { templateId, letterParamMaps, passwords, passwordInstructions } =
+      createBulkLetterDto
     const template = await this.templatesService.findOne(templateId)
     if (!template) throw new NotFoundException('Template not found')
 
@@ -63,6 +64,7 @@ export class LettersService {
       template.fields,
       letterParamMaps,
       passwords,
+      passwordInstructions,
     )
 
     if (!validationResult.success)
@@ -87,6 +89,7 @@ export class LettersService {
       const createBatchDto = {
         userId,
         templateId,
+        passwordInstructions,
       } as CreateBatchDto
 
       const batch = await this.batchesService.createWithTransaction(

--- a/backend/src/public/public.controller.ts
+++ b/backend/src/public/public.controller.ts
@@ -6,7 +6,6 @@ import {
   Param,
 } from '@nestjs/common'
 import { mapLetterToPublicDto } from 'core/dto-mappers/letter.dto-mapper'
-import { Letter } from 'database/entities'
 import { LettersService } from 'letters/letters.service'
 
 import { GetLetterPublicDto } from '~shared/dtos/letters.dto'

--- a/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
@@ -5,6 +5,7 @@ import {
   FormControl,
   FormErrorMessage,
   Heading,
+  Input,
   Spacer,
   Stack,
   Text,
@@ -48,6 +49,15 @@ export const UploadCsvForm = ({
   const { templateId } = useTemplateId()
   const { template } = useGetTemplateById(templateId)
 
+  const [passwordInstructions, setPasswordInstructions] = useState('')
+
+  const handlePasswordInstructionsChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const inputValue = event.target.value
+    setPasswordInstructions(inputValue)
+  }
+
   const downloadSample = () => {
     const csvRows = isPasswordProtected
       ? [...template.fields, 'Password']
@@ -62,7 +72,12 @@ export const UploadCsvForm = ({
 
   const handleSubmit = async (): Promise<void> => {
     const reqBody = isPasswordProtected
-      ? { templateId, letterParamMaps: parsedArr, passwords }
+      ? {
+          templateId,
+          letterParamMaps: parsedArr,
+          passwords,
+          passwordInstructions,
+        }
       : { templateId, letterParamMaps: parsedArr }
     await mutateAsync(reqBody)
   }
@@ -127,9 +142,10 @@ export const UploadCsvForm = ({
             <Text fontSize="24px" fontWeight="500">
               Add password protection
             </Text>
+            {/* TODO: Add a link to password guidelines */}
             <Text fontSize="14px" fontWeight="400">
-              Create password that citizens would have to add before accessing
-              the letter.
+              Adds a csv field for password that citizens would have to add
+              before accessing the letter. Password Guidelines{' '}
             </Text>
           </Stack>
           <Switch
@@ -139,6 +155,23 @@ export const UploadCsvForm = ({
             isChecked={isPasswordProtected}
           ></Switch>
         </Flex>
+        {isPasswordProtected && (
+          <Stack>
+            <Text fontSize="18px" fontWeight="500">
+              Password Information Callout (Optional)
+            </Text>
+            <Text fontSize="14px" fontWeight="400">
+              Describe to citizens what information they can use to unlock their
+              letter. E.g. — &quot; Use the last four digits of NRIC + DOB to
+              unlock this letter &quot;
+            </Text>
+            <Input
+              value={passwordInstructions}
+              onChange={handlePasswordInstructionsChange}
+              placeholder="Password information callout"
+            />
+          </Stack>
+        )}
         <Spacer />
         <Flex justify="space-between">
           <Button

--- a/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/UploadCsvForm.tsx
@@ -6,6 +6,7 @@ import {
   FormErrorMessage,
   Heading,
   Input,
+  Link,
   Spacer,
   Stack,
   Text,
@@ -87,6 +88,11 @@ export const UploadCsvForm = ({
   }
 
   const getErrorMessage = (): string => {
+    // place this here, since officers might input the password instructions before uploading the CSV file
+    // they wouldn't be able to see the error, if this condition is placed below the empty file condition
+    if (passwordInstructions.length != 0 && passwordInstructions.length < 10) {
+      return 'Password instructions must at least contains a minimum of 10 characters.'
+    }
     if (!file) return ''
     if (parseCsvError) {
       return parseCsvError
@@ -100,16 +106,18 @@ export const UploadCsvForm = ({
     return ''
   }
 
+  const csvFormError =
+    !!parseCsvError ||
+    uploadCsvErrors.length > 0 ||
+    (file && passwords.length > 0 !== isPasswordProtected)
+
+  const passwordInstructionsError =
+    passwordInstructions.length != 0 && passwordInstructions.length < 10
+
   return (
-    <FormControl
-      isInvalid={
-        !!parseCsvError ||
-        uploadCsvErrors.length > 0 ||
-        (file && passwords.length > 0 !== isPasswordProtected)
-      }
-    >
+    <FormControl isInvalid={csvFormError || passwordInstructionsError}>
       <VStack spacing={4} align="stretch">
-        <Heading size="sm">Upload the completed .CSV file</Heading>
+        <Heading size="md">Upload the completed .CSV file</Heading>
         <VStack align="stretch" spacing={0}>
           {file && (
             <Box
@@ -136,16 +144,18 @@ export const UploadCsvForm = ({
             isInvalid={!!parseCsvError || uploadCsvErrors.length > 0}
           />
         </VStack>
-        <FormErrorMessage>{getErrorMessage()}</FormErrorMessage>
+        {csvFormError && (
+          <FormErrorMessage>{getErrorMessage()}</FormErrorMessage>
+        )}
         <Flex justify="space-between">
           <Stack>
-            <Text fontSize="24px" fontWeight="500">
-              Add password protection
-            </Text>
-            {/* TODO: Add a link to password guidelines */}
+            <Heading size="md">Add password protection</Heading>
             <Text fontSize="14px" fontWeight="400">
               Adds a csv field for password that citizens would have to add
-              before accessing the letter. Password Guidelines{' '}
+              before accessing the letter.{' '}
+              <Link href="https://lettersg.gitbook.io/lettersg-guide/for-agency-users/bulk-generating-letters/generating-password-protected-letters">
+                Password Guidelines
+              </Link>{' '}
             </Text>
           </Stack>
           <Switch
@@ -157,9 +167,7 @@ export const UploadCsvForm = ({
         </Flex>
         {isPasswordProtected && (
           <Stack>
-            <Text fontSize="18px" fontWeight="500">
-              Password Information Callout (Optional)
-            </Text>
+            <Heading size="sm">Password Information Callout (Optional)</Heading>
             <Text fontSize="14px" fontWeight="400">
               Describe to citizens what information they can use to unlock their
               letter. E.g. — &quot; Use the last four digits of NRIC + DOB to
@@ -170,6 +178,9 @@ export const UploadCsvForm = ({
               onChange={handlePasswordInstructionsChange}
               placeholder="Password information callout"
             />
+            {passwordInstructionsError && (
+              <FormErrorMessage>{getErrorMessage()}</FormErrorMessage>
+            )}
           </Stack>
         )}
         <Spacer />

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -17,6 +17,7 @@ export const LetterPublicPage = (): JSX.Element => {
   const { letterPublicId } = useLetterPublicId()
   const [password, setPassword] = useState('')
   const [isPasswordProtected, setIsPasswordProtected] = useState(false)
+  const [passwordInstructions, setPasswordInstructions] = useState('')
 
   const { letter, isLetterLoading, error, refetchLetter } =
     useGetLetterByPublicId({
@@ -39,6 +40,9 @@ export const LetterPublicPage = (): JSX.Element => {
   useEffect(() => {
     if (error?.json?.statusCode === 401) {
       setIsPasswordProtected(true)
+      if (!passwordInstructions?.length) {
+        setPasswordInstructions(error?.json?.passwordInstructions)
+      }
     }
   }, [error])
 
@@ -60,6 +64,7 @@ export const LetterPublicPage = (): JSX.Element => {
             password={password}
             setPassword={setPassword}
             isLetterLoading={isLetterLoading}
+            passwordInstructions={passwordInstructions}
           />
         ) : (
           <VStack padding={16} spacing={8} align={'center'}>

--- a/frontend/src/features/public/components/PasswordProtectedView.tsx
+++ b/frontend/src/features/public/components/PasswordProtectedView.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  AlertIcon,
   Box,
   Button,
   FormControl,
@@ -9,6 +11,7 @@ import {
   Input,
   InputGroup,
   InputRightElement,
+  Text,
 } from '@chakra-ui/react'
 import { FC, FormEvent, PropsWithChildren, useState } from 'react'
 
@@ -16,17 +19,19 @@ import ELetters from '~/assets/ELetters.svg'
 import { ReactComponent as Hide } from '~/assets/Hide.svg'
 import { ReactComponent as Show } from '~/assets/Show.svg'
 import { ReactComponent as ShowEmpty } from '~/assets/ShowEmpty.svg'
-import { ResponseError } from '~/types/ResponseError'
+import { PasswordResponseError } from '~/types/PasswordResponseError'
+import { PASSWORD_ERROR_MESSAGE } from '~shared/constants/letters'
 import { AppGrid } from '~templates/AppGrid'
 import { AuthGridArea } from '~templates/AuthGridArea'
 import { GenericNonMobileSidebarGridArea } from '~templates/GenericNonMobileSidebarGridArea'
 
 interface PasswordProtectedViewProps {
   handleSubmit: (event: FormEvent<HTMLFormElement>) => void
-  error: ResponseError | null
+  error: PasswordResponseError | null
   password: string
   setPassword: (password: string) => void
   isLetterLoading: boolean
+  passwordInstructions?: string
 }
 
 const NonMobileSidebarGridArea: FC<PropsWithChildren> = ({ children }) => {
@@ -52,6 +57,7 @@ export const PasswordProtectedView = ({
   password,
   setPassword,
   isLetterLoading,
+  passwordInstructions,
 }: PasswordProtectedViewProps): JSX.Element => {
   const [showPassword, setShowPassword] = useState(false)
 
@@ -66,11 +72,17 @@ export const PasswordProtectedView = ({
           <form noValidate onSubmit={(event) => handleSubmit(event)}>
             <FormControl
               isInvalid={
-                !!error && error.json.message !== 'No Password provided'
+                !!error && error.json.message !== PASSWORD_ERROR_MESSAGE
               }
               mb="2.5rem"
             >
               <FormLabel fontWeight={700}>Unlock Letter</FormLabel>
+              {passwordInstructions?.length ? (
+                <Alert status="info" style={{ margin: '10px 0px 10px' }}>
+                  <AlertIcon />
+                  <Text fontSize="sm">{passwordInstructions}</Text>
+                </Alert>
+              ) : null}
               <InputGroup>
                 <Input
                   type={showPassword ? 'text' : 'password'}

--- a/frontend/src/features/public/hooks/letters.hooks.ts
+++ b/frontend/src/features/public/hooks/letters.hooks.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 
-import { ResponseError } from '~/types/ResponseError'
+import { PasswordResponseError } from '~/types/PasswordResponseError'
 import { publicQueryKeys } from '~constants/query-keys'
 import { api } from '~lib/api'
 import { GetLetterPublicDto } from '~shared/dtos/letters.dto'
@@ -24,7 +24,7 @@ export const useGetLetterByPublicId = ({
     isLoading,
     error,
     refetch: refetchLetter,
-  } = useQuery<GetLetterPublicDto, ResponseError>(
+  } = useQuery<GetLetterPublicDto, PasswordResponseError>(
     publicQueryKeys.letters(letterPublicId),
     () =>
       api

--- a/frontend/src/types/PasswordResponseError.ts
+++ b/frontend/src/types/PasswordResponseError.ts
@@ -1,0 +1,13 @@
+export type ResponseErrorJson = {
+  statusCode: number
+  message: string
+  error?: string
+}
+
+export type PasswordResponseErrorJson = ResponseErrorJson & {
+  passwordInstructions: string
+}
+
+export type PasswordResponseError = {
+  json: PasswordResponseErrorJson
+}

--- a/frontend/src/types/ResponseError.ts
+++ b/frontend/src/types/ResponseError.ts
@@ -1,9 +1,0 @@
-export type ResponseErrorJson = {
-  statusCode: number
-  message: string
-  error?: string
-}
-
-export type ResponseError = {
-  json: ResponseErrorJson
-}

--- a/shared/src/constants/letters.ts
+++ b/shared/src/constants/letters.ts
@@ -1,2 +1,3 @@
 export const BULK_MAX_ROW_LENGTH = 500
 export const MIN_PASSWORD_INSTRUCTION_LENGTH = 10
+export const PASSWORD_ERROR_MESSAGE = 'No Password provided'

--- a/shared/src/constants/letters.ts
+++ b/shared/src/constants/letters.ts
@@ -1,1 +1,2 @@
 export const BULK_MAX_ROW_LENGTH = 500
+export const MIN_PASSWORD_INSTRUCTION_LENGTH = 10

--- a/shared/src/dtos/batches.dto.ts
+++ b/shared/src/dtos/batches.dto.ts
@@ -4,4 +4,5 @@ export class CreateBatchDto {
   userId: number
   templateId: number
   rawCsv: string
+  passwordInstructions: string
 }

--- a/shared/src/dtos/letters.dto.ts
+++ b/shared/src/dtos/letters.dto.ts
@@ -21,6 +21,8 @@ export class CreateBulkLetterDto {
   @IsOptional()
   @IsArray()
   passwords?: string[]
+  @IsOptional()
+  passwordInstructions?: string
 }
 
 export enum BulkLetterValidationResultErrorMessage {


### PR DESCRIPTION
## Context

This PR adds the password instructions flow for officers to input the instructions to unlock a password protected letter. In the future PRs, we'll be completing the citizen flow for how these instructions are displayed. 

Closes [task](https://www.notion.so/opengov/Eng-Officer-side-setting-password-unlock-instructions-for-protected-letter-8f45c77a78cc4e5ba84e7bff79aa6639).

## Approach

- Allow officers to set password-unlock instructions for password protected letters
    - [backend] Modify the batch table to add `passwordInstructions` column  (done)
    - [backend] Modify the current `LettersController`, `LettersService` to save the `passwordInstructions`
   - [frontend] Update the screen, hooks and forms to add Password Information field (done)

## Before & After Screenshots

**BEFORE**:


https://github.com/opengovsg/letters/assets/25703976/987e2b4e-95c1-41db-b421-c74f6d984503


**AFTER**:

https://github.com/opengovsg/letters/assets/25703976/25209f78-34e9-40d9-951e-5990470b3c9b




## Tests
Added tests for password instructions validation:

```
[backend]  PASS  src/templates/templates-parsing.service.spec.ts (5.242 s)
[backend]  PASS  src/letters/letters-rendering.service.spec.ts (5.281 s)
[backend]  PASS  src/tracing/__tests__/trace-id.provider.spec.ts (5.49 s)
[backend]  PASS  src/letters/letters-validation.service.spec.ts (5.908 s)
[backend]  PASS  src/letters/letters-encryption.service.spec.ts (6.028 s)
[backend]  PASS  src/auth/__tests__/auth.service.spec.ts (6.165 s)
[backend]  PASS  src/auth/__tests__/auth.controller.spec.ts (6.217 s)
[backend]  PASS  src/health/__tests__/health.controller.spec.ts
[backend]  PASS  src/core/utils/generate-public-id.spec.ts
[backend]  PASS  src/batches/batches.controller.spec.ts
[backend]  PASS  src/letters/letters.service.spec.ts (6.419 s)
[backend]  PASS  src/templates/templates.service.spec.ts (6.445 s)
[backend]  PASS  src/templates/templates.controller.spec.ts
[backend]  PASS  src/batches/batches.service.spec.ts
[backend]  PASS  src/letters/letters.controller.spec.ts
[backend] 
[backend] Test Suites: 15 passed, 15 total
[backend] Tests:       42 passed, 42 total
[backend] Snapshots:   0 total
[backend] Time:        6.794 s, estimated 8 s
[backend] Ran all test suites.
[backend] npm run on-backend test exited with code 0
```
