### PR TITLE
fix: hide download button

### DIFF
--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -1,11 +1,11 @@
-import { Button, VStack } from '@chakra-ui/react'
+import { VStack } from '@chakra-ui/react'
 import { FormEvent, useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { Navigate } from 'react-router-dom'
 
 import { routes } from '~constants/routes'
 import { LetterViewer } from '~features/editor/components/LetterViewer'
-import { convertHtmlToPdf, HEIGHT_A4, WIDTH_A4 } from '~utils/htmlUtils'
+import { HEIGHT_A4, WIDTH_A4 } from '~utils/htmlUtils'
 
 import { PasswordProtectedView } from './components/PasswordProtectedView'
 import {
@@ -23,12 +23,6 @@ export const LetterPublicPage = (): JSX.Element => {
       letterPublicId,
       password,
     })
-
-  const handleDownload = () => {
-    if (letter && letter.issuedLetter) {
-      void convertHtmlToPdf(letter.issuedLetter, `${letterPublicId}.pdf`)
-    }
-  }
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -70,9 +64,6 @@ export const LetterPublicPage = (): JSX.Element => {
               minWidth={{ md: WIDTH_A4 }}
               minHeight={{ md: HEIGHT_A4 }}
             />
-            {!isLetterLoading && (
-              <Button onClick={handleDownload}>Download as .PDF</Button>
-            )}
           </VStack>
         )}
       </VStack>


### PR DESCRIPTION
## Context

We are hiding the `Download as .PDF` button for now, since users can still use browser tools for printing the letters, moreover, the pagination of letters still remains a problem. 

Closes [notion task](https://www.notion.so/opengov/Eng-Hide-download-pdf-button-9ffd0cee684444c69d87adaa0645a9f9)

## Approach

Commented out code for the `Download as .PDF` button

**Bug Fixes**:

- We are hiding the "Download as .PDF" button 

## Before & After Screenshots

**BEFORE**:
<img width="1512" alt="Screenshot 2023-07-05 at 1 48 48 AM" src="https://github.com/opengovsg/letters/assets/25703976/4d0b72d4-3ff5-4d92-83fd-68876102d542">


**AFTER**:

https://github.com/opengovsg/letters/assets/25703976/db268808-333a-4de3-a64b-60386446abe4


