### PR TITLE
chore: [citizen] password instructions

### DIFF
--- a/backend/src/batches/batches.service.ts
+++ b/backend/src/batches/batches.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { EntityManager, Repository } from 'typeorm'
 
@@ -22,6 +22,15 @@ export class BatchesService {
   ): Promise<Batch> {
     const batch = this.repository.create(createBatchDto)
     return await entityManager.save(batch)
+  }
+
+  async findOneByBatchId(id: number): Promise<Batch> {
+    const batch = await this.repository.findOneBy({
+      id,
+    })
+    if (!batch) throw new NotFoundException('Batch not found')
+
+    return batch
   }
 
   findAll() {

--- a/backend/src/letters/letters.service.ts
+++ b/backend/src/letters/letters.service.ts
@@ -7,6 +7,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm'
 import { DataSource, EntityManager, Repository } from 'typeorm'
 
+import { PASSWORD_ERROR_MESSAGE } from '~shared/constants/letters'
 import { CreateBatchDto } from '~shared/dtos/batches.dto'
 import {
   CreateBulkLetterDto,
@@ -147,8 +148,18 @@ export class LettersService {
     if (!letter) throw new NotFoundException('Letter not found')
 
     if (letter.isPasswordProtected) {
+      // this is the case, where we show the screen for entering the password
+      // and the password instructions. So here we pass the password instructions
+      // to be displayed on frontend
       if (!password) {
-        throw new UnauthorizedException('No Password provided')
+        const letterBatch = await this.batchesService.findOneByBatchId(
+          letter.batchId,
+        )
+        throw new UnauthorizedException({
+          statusCode: 401,
+          message: PASSWORD_ERROR_MESSAGE,
+          passwordInstructions: letterBatch.passwordInstructions,
+        })
       }
 
       return this.lettersEncryptionService.decryptLetter(letter, password)

--- a/backend/src/public/public.controller.ts
+++ b/backend/src/public/public.controller.ts
@@ -6,7 +6,6 @@ import {
   Param,
 } from '@nestjs/common'
 import { mapLetterToPublicDto } from 'core/dto-mappers/letter.dto-mapper'
-import { Letter } from 'database/entities'
 import { LettersService } from 'letters/letters.service'
 
 import { GetLetterPublicDto } from '~shared/dtos/letters.dto'

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -17,6 +17,7 @@ export const LetterPublicPage = (): JSX.Element => {
   const { letterPublicId } = useLetterPublicId()
   const [password, setPassword] = useState('')
   const [isPasswordProtected, setIsPasswordProtected] = useState(false)
+  const [passwordInstructions, setPasswordInstructions] = useState('')
 
   const { letter, isLetterLoading, error, refetchLetter } =
     useGetLetterByPublicId({
@@ -39,6 +40,9 @@ export const LetterPublicPage = (): JSX.Element => {
   useEffect(() => {
     if (error?.json?.statusCode === 401) {
       setIsPasswordProtected(true)
+      if (!passwordInstructions?.length) {
+        setPasswordInstructions(error?.json?.passwordInstructions)
+      }
     }
   }, [error])
 
@@ -60,6 +64,7 @@ export const LetterPublicPage = (): JSX.Element => {
             password={password}
             setPassword={setPassword}
             isLetterLoading={isLetterLoading}
+            passwordInstructions={passwordInstructions}
           />
         ) : (
           <VStack padding={16} spacing={8} align={'center'}>

--- a/frontend/src/features/public/components/PasswordProtectedView.tsx
+++ b/frontend/src/features/public/components/PasswordProtectedView.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  AlertIcon,
   Box,
   Button,
   FormControl,
@@ -9,6 +11,7 @@ import {
   Input,
   InputGroup,
   InputRightElement,
+  Text,
 } from '@chakra-ui/react'
 import { FC, FormEvent, PropsWithChildren, useState } from 'react'
 
@@ -16,17 +19,19 @@ import ELetters from '~/assets/ELetters.svg'
 import { ReactComponent as Hide } from '~/assets/Hide.svg'
 import { ReactComponent as Show } from '~/assets/Show.svg'
 import { ReactComponent as ShowEmpty } from '~/assets/ShowEmpty.svg'
-import { ResponseError } from '~/types/ResponseError'
+import { PasswordResponseError } from '~/types/PasswordResponseError'
+import { PASSWORD_ERROR_MESSAGE } from '~shared/constants/letters'
 import { AppGrid } from '~templates/AppGrid'
 import { AuthGridArea } from '~templates/AuthGridArea'
 import { GenericNonMobileSidebarGridArea } from '~templates/GenericNonMobileSidebarGridArea'
 
 interface PasswordProtectedViewProps {
   handleSubmit: (event: FormEvent<HTMLFormElement>) => void
-  error: ResponseError | null
+  error: PasswordResponseError | null
   password: string
   setPassword: (password: string) => void
   isLetterLoading: boolean
+  passwordInstructions?: string
 }
 
 const NonMobileSidebarGridArea: FC<PropsWithChildren> = ({ children }) => {
@@ -52,6 +57,7 @@ export const PasswordProtectedView = ({
   password,
   setPassword,
   isLetterLoading,
+  passwordInstructions,
 }: PasswordProtectedViewProps): JSX.Element => {
   const [showPassword, setShowPassword] = useState(false)
 
@@ -66,11 +72,17 @@ export const PasswordProtectedView = ({
           <form noValidate onSubmit={(event) => handleSubmit(event)}>
             <FormControl
               isInvalid={
-                !!error && error.json.message !== 'No Password provided'
+                !!error && error.json.message !== PASSWORD_ERROR_MESSAGE
               }
               mb="2.5rem"
             >
               <FormLabel fontWeight={700}>Unlock Letter</FormLabel>
+              {passwordInstructions?.length ? (
+                <Alert status="info" style={{ margin: '10px 0px 10px' }}>
+                  <AlertIcon />
+                  <Text fontSize="sm">{passwordInstructions}</Text>
+                </Alert>
+              ) : null}
               <InputGroup>
                 <Input
                   type={showPassword ? 'text' : 'password'}

--- a/frontend/src/features/public/hooks/letters.hooks.ts
+++ b/frontend/src/features/public/hooks/letters.hooks.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 
-import { ResponseError } from '~/types/ResponseError'
+import { PasswordResponseError } from '~/types/PasswordResponseError'
 import { publicQueryKeys } from '~constants/query-keys'
 import { api } from '~lib/api'
 import { GetLetterPublicDto } from '~shared/dtos/letters.dto'
@@ -24,7 +24,7 @@ export const useGetLetterByPublicId = ({
     isLoading,
     error,
     refetch: refetchLetter,
-  } = useQuery<GetLetterPublicDto, ResponseError>(
+  } = useQuery<GetLetterPublicDto, PasswordResponseError>(
     publicQueryKeys.letters(letterPublicId),
     () =>
       api

--- a/frontend/src/types/PasswordResponseError.ts
+++ b/frontend/src/types/PasswordResponseError.ts
@@ -1,0 +1,13 @@
+export type ResponseErrorJson = {
+  statusCode: number
+  message: string
+  error?: string
+}
+
+export type PasswordResponseErrorJson = ResponseErrorJson & {
+  passwordInstructions: string
+}
+
+export type PasswordResponseError = {
+  json: PasswordResponseErrorJson
+}

--- a/frontend/src/types/ResponseError.ts
+++ b/frontend/src/types/ResponseError.ts
@@ -1,9 +1,0 @@
-export type ResponseErrorJson = {
-  statusCode: number
-  message: string
-  error?: string
-}
-
-export type ResponseError = {
-  json: ResponseErrorJson
-}

--- a/shared/src/constants/letters.ts
+++ b/shared/src/constants/letters.ts
@@ -1,2 +1,3 @@
 export const BULK_MAX_ROW_LENGTH = 500
 export const MIN_PASSWORD_INSTRUCTION_LENGTH = 10
+export const PASSWORD_ERROR_MESSAGE = 'No Password provided'


### PR DESCRIPTION
## Context
In the previous, we added password instructions flow for the officers, in this PR we are going to be adding the flow for password instructions for citizens and how the password instructions would be shown to them before they actually open and access the letter.
Closes [insert issue #]

## Approach

- Passing the password instructions as part of the JSON error we pass, when password is required to block the letter.

**Features**:

- Show password instructions entered by the officers while generating the letters to the citizen when they access the letter. 

## Before & After Screenshots

**BEFORE**:
Enter password screen before: 
<img width="1502" alt="Screenshot 2023-07-05 at 1 30 09 PM" src="https://github.com/opengovsg/letters/assets/25703976/2c9957e1-301f-4b5b-9e64-3281115656f1">


**AFTER**:
E2E flow tested here: 

https://github.com/opengovsg/letters/assets/25703976/8989b8dd-3ce6-47f0-85a9-ada449f1f986

When no password instructions are provided:
<img width="1512" alt="Screenshot 2023-07-06 at 6 38 55 PM" src="https://github.com/opengovsg/letters/assets/25703976/7497f4ec-39e7-4f34-bda3-197aeb92833c">

