### PR TITLE
fix: add template -> request template button

### DIFF
--- a/frontend/src/features/dashboard/TemplatesPage.tsx
+++ b/frontend/src/features/dashboard/TemplatesPage.tsx
@@ -1,9 +1,6 @@
 import { Box, VStack } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
-import { useNavigate } from 'react-router-dom'
-
-import { ReactComponent as PlusCircle } from '~/assets/PlusCircle.svg'
-import { routes } from '~constants/routes'
+import { Link, useNavigate } from 'react-router-dom'
 
 import { TemplatesBody } from './components/TemplatesBody'
 
@@ -12,15 +9,12 @@ export const TemplatesPage = (): JSX.Element => {
 
   return (
     <VStack alignItems="left" spacing="0px">
-      <VStack pt={2.5} align={'center'}>
-        <Button
-          marginLeft={8}
-          alignSelf="start"
-          leftIcon={<PlusCircle />}
-          onClick={() => navigate(`/admin/${routes.admin.create}`)}
-        >
-          Add New
-        </Button>
+      <VStack pt={2.5} align={'start'}>
+        <Link to="https://go.gov.sg/letters-beta" target="_blank">
+          <Button marginLeft={8} alignSelf="start">
+            Request New Template
+          </Button>
+        </Link>
         <Box>
           <TemplatesBody />
         </Box>


### PR DESCRIPTION
## Context

Since user won't be able to create new template anyways, we are changing the button for adding new template to requesting new template and routing them to a form for requesting the creation or addition of a new template.

Closes this notion [task](https://www.notion.so/opengov/Eng-Modify-Add-New-template-button-to-Request-to-add-new-button-f48785454d78461e8d2cebd401f186b6)
## Approach

1. Change the button to a link and open the form page in a new tab, when the `Request New Template` is clicked. 

## Before & After Screenshots

**BEFORE**:
<img width="1512" alt="Screenshot 2023-07-05 at 2 52 26 PM" src="https://github.com/opengovsg/letters/assets/25703976/530bffe2-f348-4e6c-8c20-788a160a2ecf">

**AFTER**:

https://github.com/opengovsg/letters/assets/25703976/13f45621-c891-4b9b-91cc-498ce911fae7

