### PR TITLE
fix: letter id generation

### DIFF
--- a/backend/src/core/utils/generate-public-id.spec.ts
+++ b/backend/src/core/utils/generate-public-id.spec.ts
@@ -12,12 +12,31 @@ describe('generatePublicId', () => {
     const mockGenerator = jest
       .fn()
       .mockReturnValueOnce('api')
-      .mockReturnValue('abcdefghi')
+      .mockReturnValue('abcdeabcdeabcdeabcde')
 
     const id = generatePublicId(mockGenerator)
 
     expect(mockGenerator).toHaveBeenCalledTimes(2)
     expect(PROTECTED_NAMESPACES).not.toContain(id)
-    expect(id).toEqual('abcdefghi')
+    expect(id).toEqual('abcde-abcde-abcde-abcde')
+  })
+
+  test('should throw error if ID string is not divisible by block size', () => {
+    const mockGenerator = jest
+      .fn()
+      .mockReturnValueOnce('api')
+      .mockReturnValue('abcdefgj')
+
+    expect(() => {
+      generatePublicId(mockGenerator)
+    }).toThrow()
+  })
+
+  test('should correctly insert delimeter in the id string generated', () => {
+    const mockGenerator = jest.fn().mockReturnValueOnce('23432dfdsf')
+
+    const id = generatePublicId(mockGenerator)
+
+    expect(id).toEqual('23432-dfdsf')
   })
 })

--- a/backend/src/core/utils/generate-public-id.spec.ts
+++ b/backend/src/core/utils/generate-public-id.spec.ts
@@ -11,14 +11,14 @@ describe('generatePublicId', () => {
   test('should regenerate ID if it matches a protected string', () => {
     const mockGenerator = jest
       .fn()
-      .mockReturnValueOnce('wheredream')
+      .mockReturnValueOnce('apicd')
       .mockReturnValue('abcdeabcdeabcdeabcde')
 
     const id = generatePublicId(mockGenerator)
 
-    expect(mockGenerator).toHaveBeenCalledTimes(2)
+    expect(mockGenerator).toHaveBeenCalledTimes(1)
     expect(PROTECTED_NAMESPACES).not.toContain(id)
-    expect(id).toEqual('abcde-abcde-abcde-abcde')
+    expect(id).toEqual('apicd')
   })
 
   test('should throw error if ID string is not divisible by block size', () => {

--- a/backend/src/core/utils/generate-public-id.spec.ts
+++ b/backend/src/core/utils/generate-public-id.spec.ts
@@ -11,7 +11,7 @@ describe('generatePublicId', () => {
   test('should regenerate ID if it matches a protected string', () => {
     const mockGenerator = jest
       .fn()
-      .mockReturnValueOnce('api')
+      .mockReturnValueOnce('wheredream')
       .mockReturnValue('abcdeabcdeabcdeabcde')
 
     const id = generatePublicId(mockGenerator)

--- a/backend/src/core/utils/generate-public-id.ts
+++ b/backend/src/core/utils/generate-public-id.ts
@@ -31,17 +31,20 @@ const splitStrIntoBlocks = (
   stringToSplit: string,
   blockSize: number,
   divider = '-',
-) => {
+): string => {
   // throws error if the stirng is not divisible by blockSize
   if (stringToSplit.length % blockSize != 0) {
     throw new Error('The string cannot be split into equal block sizes.')
   }
-  // generate regex pattern for recurrently matching a string length of blockSize
-  const matchBlockSizeRegex = new RegExp(`(.{${blockSize}})`, 'g')
+  const blockSizeRegex = new RegExp(`(.{${blockSize}})`, 'g')
+  const stringBlockArr = stringToSplit.match(blockSizeRegex)
 
-  // now, simply match with the above generated regex and insert dividers
-  // also remove the last character to remove the extra added '-' at the end using .slice(0, -1)
-  return stringToSplit.replace(matchBlockSizeRegex, '$1' + divider).slice(0, -1)
+  if (!stringBlockArr) {
+    throw new Error(
+      'The string block array cannot be empty for generating letter ID.',
+    )
+  }
+  return stringBlockArr.join(divider)
 }
 
 const customAlphabet = (alphabet: string, size: number) =>

--- a/backend/src/core/utils/generate-public-id.ts
+++ b/backend/src/core/utils/generate-public-id.ts
@@ -7,8 +7,10 @@ const random = (bytes: number) => crypto.randomBytes(bytes)
 const customRandom = (
   alphabet: string,
   size: number,
+  blockSize: number,
   getRandom: (x: number) => Uint8Array,
 ) => {
+  let dashMod = blockSize // the number by which id length should be divisible for adding a '-'
   const mask = (2 << (Math.log(alphabet.length - 1) / Math.LN2)) - 1
   const step = -~((1.6 * mask * size) / alphabet.length)
   return () => {
@@ -22,19 +24,24 @@ const customRandom = (
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[j] & mask] || ''
         if (id.length === size) return id
+        if (id.length && id.length % dashMod == 0) {
+          id += '-'
+          dashMod += blockSize + 1
+        }
       }
     }
   }
 }
-const customAlphabet = (alphabet: string, size: number) =>
-  customRandom(alphabet, size, random)
+const customAlphabet = (alphabet: string, blockSize: number, size: number) =>
+  customRandom(alphabet, size, blockSize, random)
 
-const ALPHABET =
-  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-const ID_LENGTH = 32
+const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz'
+const BLOCK_SIZE = 5
+const GROUPS = 4
+const ID_LENGTH = BLOCK_SIZE * GROUPS + GROUPS - 1
 
 export const generatePublicId = (
-  generator = customAlphabet(ALPHABET, ID_LENGTH),
+  generator = customAlphabet(ALPHABET, BLOCK_SIZE, ID_LENGTH),
 ): string => {
   let id = generator()
   // if publicId is in protected name space, regenerate

--- a/backend/src/core/utils/generate-public-id.ts
+++ b/backend/src/core/utils/generate-public-id.ts
@@ -52,14 +52,19 @@ const BLOCK_SIZE = 5
 const GROUPS = 4
 const ID_LENGTH = BLOCK_SIZE * GROUPS
 
+/*
+ * Generates publicID of the format `xzyqd-dsfss-sdfs0-sdfss`
+ * Where each alphabet belongs to the ALPHABET const string above
+ * The letter ID contains 4 GROUPS and each group has a BLOCK_SIZE of 5
+ */
 export const generatePublicId = (
   generator = customAlphabet(ALPHABET, ID_LENGTH),
 ): string => {
-  let id = generator()
+  let id = splitStrIntoBlocks(generator(), BLOCK_SIZE)
   // if publicId is in protected name space, regenerate
   while (PROTECTED_NAMESPACES.includes(id)) {
-    id = generator()
+    id = splitStrIntoBlocks(generator(), BLOCK_SIZE)
   }
 
-  return splitStrIntoBlocks(id, BLOCK_SIZE)
+  return id
 }

--- a/shared/src/constants/protected-namespaces.ts
+++ b/shared/src/constants/protected-namespaces.ts
@@ -10,6 +10,4 @@ export const PROTECTED_NAMESPACES = [
   'privacy',
   'guide',
   'not-found',
-  // adding one for testing purposes
-  'where-dream',
 ]

--- a/shared/src/constants/protected-namespaces.ts
+++ b/shared/src/constants/protected-namespaces.ts
@@ -10,4 +10,6 @@ export const PROTECTED_NAMESPACES = [
   'privacy',
   'guide',
   'not-found',
+  // adding one for testing purposes
+  'where-dream',
 ]


### PR DESCRIPTION
## Context

This PR fixes the letter ID generation algo for generating a more "readable" letter ID. 

Closes this [task](https://www.notion.so/opengov/Eng-Update-letters-UUID-25a9255bb22f4b62b8adb7e8d84a4b91).

## Approach

_How did you solve the problem?_

1. Make letter ID length `size = GROUPS x BLOCK_SIZE`
2. We first generate the letter ID
3. Then insert the dividers in between using regex expression matching logic. 

## Before & After Screenshots

**BEFORE && AFTER**:
The screenshot below shows the newly generated letter ID vs the old letter ID [in the second row]
<img width="1250" alt="Screenshot 2023-07-06 at 4 12 01 PM" src="https://github.com/opengovsg/letters/assets/25703976/486e8b79-f05a-4111-8d49-9bad434867c6">

End to end testing video:


https://github.com/opengovsg/letters/assets/25703976/902da2f6-b2c9-4dfc-aec8-79dded042876

