### PR TITLE
chore: add password validation

### DIFF
--- a/backend/src/letters/letters-validation.service.spec.ts
+++ b/backend/src/letters/letters-validation.service.spec.ts
@@ -39,7 +39,7 @@ describe('LettersValidationService', () => {
     })
 
     it('should fail when one password is missing ', () => {
-      const passwords: string[] = ['hunter2', '', 'hunter2']
+      const passwords: string[] = ['hunter22', '', 'hunter22']
       const fields = ['field1']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -59,6 +59,55 @@ describe('LettersValidationService', () => {
       expect(result.message).toEqual('Malformed bulk create object')
       expect(result.errors).toEqual([
         { id: 1, param: 'Password', message: 'Missing param' },
+      ])
+    })
+
+    it('should fail when anyone password is not alphanumeric ', () => {
+      const passwords: string[] = ['hunter#22', '##23232243', 'hunter22']
+      const fields = ['field1']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual('Malformed bulk create object')
+      expect(result.errors).toEqual([
+        { id: 0, param: 'Password', message: 'Password is not alphanumeric' },
+        { id: 1, param: 'Password', message: 'Password is not alphanumeric' },
+      ])
+    })
+
+    it('should fail when anyone password is less than 8 characters ', () => {
+      const passwords: string[] = ['hunter2', 'hunter22', 'hunter22']
+      const fields = ['field1']
+      const letterParamMaps: LetterParamMaps = [
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+        {
+          field1: 'param1',
+        },
+      ]
+
+      const result = service.validateBulk(fields, letterParamMaps, passwords)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toEqual('Malformed bulk create object')
+      expect(result.errors).toEqual([
+        { id: 0, param: 'Password', message: 'Short password' },
       ])
     })
 
@@ -87,7 +136,7 @@ describe('LettersValidationService', () => {
     })
 
     it('should succeed when all passwords are provided ', () => {
-      const passwords: string[] = ['hunter2', 'hunter2', 'hunter2']
+      const passwords: string[] = ['hunter22', 'hunter22', 'hunter22']
       const fields = ['field1']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -234,7 +283,7 @@ describe('LettersValidationService', () => {
 
   describe('validate Bulk', () => {
     it('should succeed when request data is valid', () => {
-      const passwords: string[] = ['hunter2', 'hunter2']
+      const passwords: string[] = ['hunter22', 'hunter22']
       const fields = ['field1', 'field2', 'field3']
       const letterParamMaps: LetterParamMaps = [
         {
@@ -257,7 +306,7 @@ describe('LettersValidationService', () => {
     })
 
     it('should raise errors with correct ids and messages when request data is not valid', () => {
-      const passwords: string[] = ['hunter2', '']
+      const passwords: string[] = ['hunter22', '']
       const fields = ['field1', 'field2', 'field3', 'field missing']
       const letterParamMaps: LetterParamMaps = [
         {

--- a/frontend/src/features/issue/BulkIssueDrawer/UploadCsvErrorsTable.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/UploadCsvErrorsTable.tsx
@@ -42,6 +42,27 @@ export const UploadCsvErrorsTable = ({
     )
   }
 
+  const getErrorMessage = (errorMessage: string): string => {
+    console.log('this is the error messsage', errorMessage)
+    if (
+      errorMessage === BulkLetterValidationResultErrorMessage.INVALID_ATTRIBUTE
+    ) {
+      return ' is not a valid attribute'
+    }
+    if (
+      errorMessage ===
+      BulkLetterValidationResultErrorMessage.PASSWORD_NOT_ALPHANUMERIC
+    ) {
+      return ' must be alphanumeric.'
+    }
+    if (
+      errorMessage === BulkLetterValidationResultErrorMessage.SHORT_PASSWORD
+    ) {
+      return ' must contains a minimum of 8 characters.'
+    }
+    return 'is missing'
+  }
+
   const errorsByRow = uploadCsvErrors.reduce(
     (errorGroup: Array<BulkLetterValidationResultError[]>, item) => {
       if (errorGroup[item.id]) {
@@ -66,11 +87,7 @@ export const UploadCsvErrorsTable = ({
                 {/* Add 1 because index starts from 0 actually */}
                 {index + 1}
                 {'. '}
-                {error.param}{' '}
-                {error.message ===
-                BulkLetterValidationResultErrorMessage.INVALID_ATTRIBUTE
-                  ? 'is not a valid attribute'
-                  : 'is missing'}
+                {error.param} {getErrorMessage(error.message)}
               </Text>
             )
           })}

--- a/shared/src/constants/letters.ts
+++ b/shared/src/constants/letters.ts
@@ -1,1 +1,3 @@
 export const BULK_MAX_ROW_LENGTH = 500
+export const MIN_PASSWORD_LENGTH = 8
+export const ALPHANUMERIC_PASSWORD_REGEX = /^[a-zA-Z0-9]+$/

--- a/shared/src/dtos/letters.dto.ts
+++ b/shared/src/dtos/letters.dto.ts
@@ -26,6 +26,8 @@ export class CreateBulkLetterDto {
 export enum BulkLetterValidationResultErrorMessage {
   INVALID_ATTRIBUTE = 'Invalid attribute in param',
   MISSING_PARAM = 'Missing param',
+  SHORT_PASSWORD = 'Short password',
+  PASSWORD_NOT_ALPHANUMERIC = 'Password is not alphanumeric',
 }
 
 export class BulkLetterValidationResultError {


### PR DESCRIPTION
## Context

_Why does this PR exist? What problem are you trying to solve? What issue does this close?_

Closes this [task](https://www.notion.so/opengov/Eng-Password-validation-5083a069d9d245fdb32d5e371eba481c)

## Approach
1. Added two more error types for short password and alphanumeric password
2. Based on the condition not met, we show the same error to the user 

One thing I was not too sure about was whether we should be grouping these errors, but then it might not be super obvious what is the exact error. 

**Features**:
- Add password validation for when the password entered by the officer is less than 8 characters 
- Add password validation for when the password entered by the officer is not alphanumeric

## Before & After Screenshots

**BEFORE**:
Errors before making the changes for password validation:
<img width="1512" alt="Screenshot 2023-07-06 at 5 17 44 PM" src="https://github.com/opengovsg/letters/assets/25703976/16f64733-f23f-4dd6-a752-ef8bdeb821d9">

**AFTER**:
Tested on various test cases:
<img width="1512" alt="Screenshot 2023-07-06 at 5 15 59 PM" src="https://github.com/opengovsg/letters/assets/25703976/8eb1c7b2-8f23-487b-9e82-730be9c5ccf1">

This is what the uploaded CSV looks like:
<img width="300" alt="Screenshot 2023-07-05 at 5 09 02 PM" src="https://github.com/opengovsg/letters/assets/25703976/9f4ed487-4ee4-4112-95b8-3f2533261f53">




