### PR TITLE
fix: template creation route

### DIFF
--- a/frontend/src/app/routes/admin.routes.tsx
+++ b/frontend/src/app/routes/admin.routes.tsx
@@ -12,37 +12,41 @@ import { BulkIssueDrawer } from '~features/issue/BulkIssueDrawer'
 export const adminRoutes: RouteObject[] = [
   {
     index: true,
-    element: <Navigate to={routes.admin.templates} />,
+    element: <Navigate to={routes.admin.templates.index} />,
   },
   {
     path: routes.admin.login,
     element: <LoginPage />,
   },
   {
-    path: routes.admin.templates,
-    element: (
-      <AdminProtectedRoute>
-        <AdminLayout />
-      </AdminProtectedRoute>
-    ),
+    path: routes.admin.templates.index,
     children: [
       {
-        index: true,
-        element: <TemplatesPage />,
+        element: (
+          <AdminProtectedRoute>
+            <AdminLayout />
+          </AdminProtectedRoute>
+        ),
+        children: [
+          {
+            index: true,
+            element: <TemplatesPage />,
+          },
+        ],
       },
-    ],
-  },
-  {
-    path: routes.admin.create,
-    element: (
-      <AdminProtectedRoute>
-        <Outlet />
-      </AdminProtectedRoute>
-    ),
-    children: [
       {
-        index: true,
-        element: <CreateTemplatePage />,
+        path: routes.admin.templates.create,
+        element: (
+          <AdminProtectedRoute>
+            <Outlet />
+          </AdminProtectedRoute>
+        ),
+        children: [
+          {
+            index: true,
+            element: <CreateTemplatePage />,
+          },
+        ],
       },
     ],
   },
@@ -61,7 +65,7 @@ export const adminRoutes: RouteObject[] = [
     ],
   },
   {
-    path: `${routes.admin.templates}/:templateId/issue`,
+    path: `${routes.admin.templates.index}/:templateId/issue`,
     element: (
       <AdminProtectedRoute>
         <AdminLayout />
@@ -81,6 +85,6 @@ export const adminRoutes: RouteObject[] = [
   },
   {
     path: '*',
-    element: <Navigate to={routes.admin.templates} />,
+    element: <Navigate to={routes.admin.templates.index} />,
   },
 ]

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -21,8 +21,8 @@ export const Sidebar = ({ children }: { children: ReactNode }) => {
           <VStack w="full" align="stretch" spacing={0}>
             <SidebarButton
               name={'Templates'}
-              isSelected={!!useMatch(`/admin/${routes.admin.templates}`)}
-              onClick={() => navigate(`/admin/${routes.admin.templates}`)}
+              isSelected={!!useMatch(`/admin/${routes.admin.templates.index}`)}
+              onClick={() => navigate(`/admin/${routes.admin.templates.index}`)}
             />
             <SidebarButton
               name={'Issued Letters'}

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -7,8 +7,10 @@ export const routes = {
   admin: {
     index: 'admin',
     login: 'login',
-    templates: 'templates',
+    templates: {
+      index: 'templates',
+      create: 'create',
+    },
     letters: 'letters',
-    create: 'create',
   },
 }

--- a/frontend/src/features/create/CreateTemplatePage.tsx
+++ b/frontend/src/features/create/CreateTemplatePage.tsx
@@ -23,7 +23,7 @@ export const CreateTemplatePage = (): JSX.Element => {
             aria-label="back"
             variant="clear"
             icon={<BiLeftArrowAlt style={{ color: '#2C2E34' }} />}
-            onClick={() => navigate(`/admin/${routes.admin.templates}`)}
+            onClick={() => navigate(`/admin/${routes.admin.templates.index}`)}
             _hover={{ background: 'none' }}
             size="lg"
           />

--- a/frontend/src/features/create/components/CreateTemplateModal.tsx
+++ b/frontend/src/features/create/components/CreateTemplateModal.tsx
@@ -37,7 +37,7 @@ export const CreateTemplateModal = ({
   const { mutateAsync, isLoading } = useCreateTemplateMutation({
     onSuccess: () => {
       onClose()
-      navigate(`/admin/${routes.admin.templates}`)
+      navigate(`/admin/${routes.admin.templates.index}`)
     },
   })
   const {

--- a/frontend/src/features/issue/BulkIssueDrawer.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer.tsx
@@ -45,7 +45,7 @@ export const BulkIssueDrawer = (): JSX.Element => {
   const [bulkLetters, setBulkLetters] = useState<GetBulkLetterDto[]>([])
 
   const onClose = () =>
-    navigate(`/${routes.admin.index}/${routes.admin.templates}`)
+    navigate(`/${routes.admin.index}/${routes.admin.templates.index}`)
 
   return (
     <Drawer size="lg" isOpen placement="right" onClose={onClose}>


### PR DESCRIPTION
## Context

This PR changes the route to template creation from `{host}/admin/create` to `{host}/admin/templates/create`

Closes this [task](https://www.notion.so/opengov/bug-Fix-frontend-route-for-template-creation-to-admin-templates-create-instead-of-admin-create-480231d157024e838e3e821150ad8349)

## Approach

- Nested the `create` path under `templates` route section in `routes.ts`
- Moved path to template creation page under `templates` route
- Updated routes to template dashboard for components navigating to it

