### PR TITLE
fix: template variable whitespaces

### DIFF
--- a/backend/src/templates/templates-parsing.service.ts
+++ b/backend/src/templates/templates-parsing.service.ts
@@ -8,9 +8,10 @@ import { getTemplateFields, parseTemplateField } from '~shared/util/templates'
 export class TemplatesParsingService {
   parseTemplate(createTemplateDto: CreateTemplateDto): Partial<Template> {
     const { html } = createTemplateDto
+    const replacedHtml = html.replace(/&nbsp;/g, ' ')
 
     // extract valid fields
-    const validFields: string[] = getTemplateFields(html)
+    const validFields: string[] = getTemplateFields(replacedHtml)
 
     // make fields lowercase, handle whitespace, deduplicate
     const parsedFields: string[] = []
@@ -20,7 +21,7 @@ export class TemplatesParsingService {
     })
 
     // for each valid field, replace field in html with the lowercased and trimmed version
-    let parsedHtml: string = html
+    let parsedHtml: string = replacedHtml
     validFields.forEach((validField: string) => {
       parsedHtml = parsedHtml.replaceAll(
         `{{${validField}}}`,

--- a/shared/src/util/templates.ts
+++ b/shared/src/util/templates.ts
@@ -12,7 +12,4 @@ export const getTemplateFields = (html: string): string[] => {
 }
 
 export const parseTemplateField = (field: string): string =>
-  field
-    .replace(/&nbsp;/g, '')
-    .trim()
-    .toLowerCase()
+  field.trim().toLowerCase()


### PR DESCRIPTION
## Context

This PR fixes the issue where there are cases of leading and trailing whitespaces of template variables not being trimmed as it should be, it was observed that `&nbsp;` characters were not being treated as whitespaces and thus not adhering to the parsing logic during creation.

Closes this [task](https://www.notion.so/opengov/bug-whitespace-trimming-before-and-after-template-variables-not-working-on-variable-validation-e5934f9cfb3642398e30d6cb7bb039b1?pvs=4)

## Approach

- Added a line to replace all `&nbsp;` characters in the html string with whitespace before parsing in `TemplatesParsingService`
- Removed replacing `&nbsp;` in `parseTemplateField` as there will no longer be instances of `&nbsp;` still existing in the string

## Before & After Screenshots

**BEFORE**:

https://github.com/opengovsg/letters/assets/119388168/13249785-a8b0-48d9-8d00-525cbc29d82a



**AFTER**:

https://github.com/opengovsg/letters/assets/119388168/0ed53078-0184-46b7-8eb5-ada7095aad9f

