### PR TITLE
Feat/a4 resize

### DIFF
--- a/frontend/src/constants/theme.ts
+++ b/frontend/src/constants/theme.ts
@@ -1,0 +1,1 @@
+export const DRAWER_WIDTH_IN_PIXELS = 672 // TODO: should be able to avoid hardcoding by reading from parent component

--- a/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
+++ b/frontend/src/features/dashboard/components/IssuedLetterDrawer.tsx
@@ -23,7 +23,9 @@ import { BiCopy, BiLeftArrowAlt } from 'react-icons/bi'
 import { Link as RouterLink } from 'react-router-dom'
 
 import { IconButton } from '~components/IconButton'
+import { DRAWER_WIDTH_IN_PIXELS } from '~constants/theme'
 import { LetterViewer } from '~features/editor/components/LetterViewer'
+import { calculateTransformScale } from '~features/public/hooks/useTransformScale'
 import { GetLetterDto } from '~shared/dtos/letters.dto'
 import { getLetterPublicLink } from '~utils/linkUtils'
 
@@ -114,7 +116,7 @@ export const IssuedLetterDrawer = ({
                 }
               />
               <GridItem
-                heading="Read Reciept"
+                heading="Read Receipt"
                 content={<Text>{letter.firstReadAt ?? 'Unread'}</Text>}
               />
               <GridItem
@@ -142,6 +144,10 @@ export const IssuedLetterDrawer = ({
                     <LetterViewer
                       isLoading={false}
                       html={letter.issuedLetter}
+                      transformOrigin="top"
+                      transform={`scale(${calculateTransformScale(
+                        DRAWER_WIDTH_IN_PIXELS,
+                      )})`} // TODO: should be able to avoid hardcoding by reading from parent drawer component
                     />
                   }
                 />

--- a/frontend/src/features/editor/components/LetterViewer.tsx
+++ b/frontend/src/features/editor/components/LetterViewer.tsx
@@ -1,5 +1,5 @@
 import { Box, BoxProps, HStack, Spinner, Text, VStack } from '@chakra-ui/react'
-import { Dispatch, useCallback } from 'react'
+import { forwardRef, LegacyRef } from 'react'
 
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
 import { HEIGHT_A4, WIDTH_A4 } from '~utils/htmlUtils'
@@ -10,25 +10,13 @@ interface LetterViewerProps extends BoxProps {
   letterPublicId?: string
   html: string | undefined
   isLoading: boolean
-  setHeight?: Dispatch<React.SetStateAction<number | undefined>>
 }
 
-export const LetterViewer = ({
-  letterPublicId,
-  html,
-  isLoading,
-  setHeight,
-  ...styleProps
-}: LetterViewerProps): JSX.Element => {
-  const ref = useCallback(
-    (node: HTMLDivElement) => {
-      if (node !== null) {
-        setHeight && setHeight(node.offsetHeight)
-      }
-    },
-    [setHeight],
-  )
-
+export const LetterViewerInner = (
+  props: LetterViewerProps,
+  ref: LegacyRef<HTMLDivElement> | undefined,
+): JSX.Element => {
+  const { letterPublicId, html, isLoading, ...styleProps } = props
   if (isLoading || !html) {
     return <Spinner />
   }
@@ -79,3 +67,4 @@ export const LetterViewer = ({
     </VStack>
   )
 }
+export const LetterViewer = forwardRef(LetterViewerInner)

--- a/frontend/src/features/editor/components/LetterViewer.tsx
+++ b/frontend/src/features/editor/components/LetterViewer.tsx
@@ -25,7 +25,7 @@ export const LetterViewer = ({
   return (
     <VStack {...styleProps} spacing={0}>
       <Box
-        height={HEIGHT_A4}
+        minHeight={HEIGHT_A4}
         width={WIDTH_A4}
         borderX="2px"
         borderY="2px"

--- a/frontend/src/features/editor/components/LetterViewer.tsx
+++ b/frontend/src/features/editor/components/LetterViewer.tsx
@@ -1,6 +1,7 @@
 import { Box, BoxProps, HStack, Spinner, Text, VStack } from '@chakra-ui/react'
 
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
+import { HEIGHT_A4, WIDTH_A4 } from '~utils/htmlUtils'
 
 import { LetterQRCode } from './LetterQRCode'
 
@@ -22,11 +23,12 @@ export const LetterViewer = ({
   const cleanHtml = sanitizeHtml(html)
 
   return (
-    <VStack spacing={0}>
+    <VStack {...styleProps} spacing={0}>
       <Box
-        {...styleProps}
+        height={HEIGHT_A4}
+        width={WIDTH_A4}
         borderX="2px"
-        borderTop="2px"
+        borderY="2px"
         borderColor="base.divider.medium"
         bg="white"
       >

--- a/frontend/src/features/editor/components/LetterViewer.tsx
+++ b/frontend/src/features/editor/components/LetterViewer.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps, HStack, Spinner, Text, VStack } from '@chakra-ui/react'
+import { Dispatch, useCallback } from 'react'
 
 import { sanitizeHtml } from '~shared/util/html-sanitizer'
 import { HEIGHT_A4, WIDTH_A4 } from '~utils/htmlUtils'
@@ -9,21 +10,32 @@ interface LetterViewerProps extends BoxProps {
   letterPublicId?: string
   html: string | undefined
   isLoading: boolean
+  setHeight?: Dispatch<React.SetStateAction<number | undefined>>
 }
 
 export const LetterViewer = ({
   letterPublicId,
   html,
   isLoading,
+  setHeight,
   ...styleProps
 }: LetterViewerProps): JSX.Element => {
+  const ref = useCallback(
+    (node: HTMLDivElement) => {
+      if (node !== null) {
+        setHeight && setHeight(node.offsetHeight)
+      }
+    },
+    [setHeight],
+  )
+
   if (isLoading || !html) {
     return <Spinner />
   }
   const cleanHtml = sanitizeHtml(html)
 
   return (
-    <VStack {...styleProps} spacing={0}>
+    <VStack {...styleProps} spacing={0} ref={ref}>
       <Box
         minHeight={HEIGHT_A4}
         width={WIDTH_A4}

--- a/frontend/src/features/issue/BulkIssueDrawer/PreviewTemplate.tsx
+++ b/frontend/src/features/issue/BulkIssueDrawer/PreviewTemplate.tsx
@@ -1,7 +1,9 @@
 import { Box } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
+import { DRAWER_WIDTH_IN_PIXELS } from '~constants/theme'
 import { LetterViewer } from '~features/editor/components/LetterViewer'
+import { calculateTransformScale } from '~features/public/hooks/useTransformScale'
 
 import { useGetTemplateById, useTemplateId } from '../hooks/templates.hooks'
 
@@ -18,7 +20,14 @@ export const PreviewTemplate = ({
     <>
       <Box padding={8} flex="1" overflowY="auto" paddingBottom="6rem">
         {/* paddingBottom height to account for sticky button */}
-        <LetterViewer html={template?.html} isLoading={isTemplatesLoading} />
+        <LetterViewer
+          html={template?.html}
+          isLoading={isTemplatesLoading}
+          transformOrigin="top"
+          transform={`scale(${calculateTransformScale(
+            DRAWER_WIDTH_IN_PIXELS,
+          )})`} // TODO: should be able to avoid hardcoding by reading from parent drawer component
+        />
       </Box>
       <Box
         position="fixed"

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -1,11 +1,10 @@
-import { Box, useDimensions, VStack } from '@chakra-ui/react'
-import { FormEvent, useEffect, useRef, useState } from 'react'
+import { Box, VStack } from '@chakra-ui/react'
+import { FormEvent, useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { Navigate } from 'react-router-dom'
 
 import { routes } from '~constants/routes'
 import { LetterViewer } from '~features/editor/components/LetterViewer'
-import { HEIGHT_A4 } from '~utils/htmlUtils'
 
 import { PasswordProtectedView } from './components/PasswordProtectedView'
 import {

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -1,23 +1,25 @@
-import { VStack } from '@chakra-ui/react'
+import { Box, VStack } from '@chakra-ui/react'
 import { FormEvent, useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { Navigate } from 'react-router-dom'
 
 import { routes } from '~constants/routes'
 import { LetterViewer } from '~features/editor/components/LetterViewer'
-import { HEIGHT_A4, WIDTH_A4 } from '~utils/htmlUtils'
+import { HEIGHT_A4 } from '~utils/htmlUtils'
 
 import { PasswordProtectedView } from './components/PasswordProtectedView'
 import {
   useGetLetterByPublicId,
   useLetterPublicId,
 } from './hooks/letters.hooks'
+import { useTransformScale } from './hooks/useTransformScale'
 
 export const LetterPublicPage = (): JSX.Element => {
   const { letterPublicId } = useLetterPublicId()
   const [password, setPassword] = useState('')
   const [isPasswordProtected, setIsPasswordProtected] = useState(false)
   const [passwordInstructions, setPasswordInstructions] = useState('')
+  const transformScale = useTransformScale()
 
   const { letter, isLetterLoading, error, refetchLetter } =
     useGetLetterByPublicId({
@@ -49,29 +51,28 @@ export const LetterPublicPage = (): JSX.Element => {
       <Helmet>
         <meta name="robots" content="noindex" data-react-helmet="true" />
       </Helmet>
-      <VStack alignItems="left" spacing="0px">
-        {isPasswordProtected && !letter ? (
-          <PasswordProtectedView
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            handleSubmit={handleSubmit}
-            error={error}
-            password={password}
-            setPassword={setPassword}
-            isLetterLoading={isLetterLoading}
-            passwordInstructions={passwordInstructions}
-          />
-        ) : (
-          <VStack padding={16} spacing={8} align={'center'}>
+      {isPasswordProtected && !letter ? (
+        <PasswordProtectedView
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises
+          handleSubmit={handleSubmit}
+          error={error}
+          password={password}
+          setPassword={setPassword}
+          isLetterLoading={isLetterLoading}
+        />
+      ) : (
+        <Box w="full" bg="gray.100" height={(HEIGHT_A4 + 200) * transformScale}>
+          <VStack padding={4} spacing={4} align={'center'}>
             <LetterViewer
               letterPublicId={letterPublicId}
               html={letter?.issuedLetter}
               isLoading={isLetterLoading}
-              minWidth={{ md: WIDTH_A4 }}
-              minHeight={{ md: HEIGHT_A4 }}
+              transform={`scale(${transformScale})`}
+              transformOrigin="top"
             />
           </VStack>
-        )}
-      </VStack>
+        </Box>
+      )}
     </>
   )
 }

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -59,6 +59,7 @@ export const LetterPublicPage = (): JSX.Element => {
           password={password}
           setPassword={setPassword}
           isLetterLoading={isLetterLoading}
+          passwordInstructions={passwordInstructions}
         />
       ) : (
         <Box w="full" bg="gray.100">

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -24,7 +24,7 @@ export const LetterPublicPage = (): JSX.Element => {
   const letterViewerRef = useCallback(
     (node: HTMLDivElement) => {
       if (node !== null) {
-        setLetterHeight && setLetterHeight(node.offsetHeight)
+        setLetterHeight(node.offsetHeight)
       }
     },
     [setLetterHeight],

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -19,6 +19,7 @@ export const LetterPublicPage = (): JSX.Element => {
   const [isPasswordProtected, setIsPasswordProtected] = useState(false)
   const [passwordInstructions, setPasswordInstructions] = useState('')
   const transformScale = useTransformScale()
+  const [letterHeight, setLetterHeight] = useState<number | undefined>(0)
 
   const { letter, isLetterLoading, error, refetchLetter } =
     useGetLetterByPublicId({
@@ -62,13 +63,19 @@ export const LetterPublicPage = (): JSX.Element => {
         />
       ) : (
         <Box w="full" bg="gray.100">
-          <VStack padding={4} spacing={4} align={'center'}>
+          <VStack
+            padding={4}
+            spacing={4}
+            align={'center'}
+            height={letterHeight ? letterHeight * transformScale + 50 : 'auto'}
+          >
             <LetterViewer
               letterPublicId={letterPublicId}
               html={letter?.issuedLetter}
               isLoading={isLetterLoading}
               transform={`scale(${transformScale})`}
               transformOrigin="top"
+              setHeight={setLetterHeight}
             />
           </VStack>
         </Box>

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -1,5 +1,5 @@
-import { Box, VStack } from '@chakra-ui/react'
-import { FormEvent, useEffect, useState } from 'react'
+import { Box, useDimensions, VStack } from '@chakra-ui/react'
+import { FormEvent, useEffect, useRef, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { Navigate } from 'react-router-dom'
 
@@ -61,7 +61,7 @@ export const LetterPublicPage = (): JSX.Element => {
           isLetterLoading={isLetterLoading}
         />
       ) : (
-        <Box w="full" bg="gray.100" height={(HEIGHT_A4 + 200) * transformScale}>
+        <Box w="full" bg="gray.100">
           <VStack padding={4} spacing={4} align={'center'}>
             <LetterViewer
               letterPublicId={letterPublicId}

--- a/frontend/src/features/public/LetterPublicPage.tsx
+++ b/frontend/src/features/public/LetterPublicPage.tsx
@@ -1,5 +1,5 @@
 import { Box, VStack } from '@chakra-ui/react'
-import { FormEvent, useEffect, useState } from 'react'
+import { FormEvent, useCallback, useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { Navigate } from 'react-router-dom'
 
@@ -20,6 +20,15 @@ export const LetterPublicPage = (): JSX.Element => {
   const [passwordInstructions, setPasswordInstructions] = useState('')
   const transformScale = useTransformScale()
   const [letterHeight, setLetterHeight] = useState<number | undefined>(0)
+
+  const letterViewerRef = useCallback(
+    (node: HTMLDivElement) => {
+      if (node !== null) {
+        setLetterHeight && setLetterHeight(node.offsetHeight)
+      }
+    },
+    [setLetterHeight],
+  )
 
   const { letter, isLetterLoading, error, refetchLetter } =
     useGetLetterByPublicId({
@@ -70,12 +79,12 @@ export const LetterPublicPage = (): JSX.Element => {
             height={letterHeight ? letterHeight * transformScale + 50 : 'auto'}
           >
             <LetterViewer
+              ref={letterViewerRef}
               letterPublicId={letterPublicId}
               html={letter?.issuedLetter}
               isLoading={isLetterLoading}
               transform={`scale(${transformScale})`}
               transformOrigin="top"
-              setHeight={setLetterHeight}
             />
           </VStack>
         </Box>

--- a/frontend/src/features/public/hooks/useTransformScale.ts
+++ b/frontend/src/features/public/hooks/useTransformScale.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { WIDTH_A4 } from '~utils/htmlUtils'
+
+export const calculateTransformScale = (viewportWidth: number): number =>
+  // For viewports with width smaller than A4, we want the letter to take up 90% of the viewport
+  Math.min(viewportWidth * 0.9, WIDTH_A4) / WIDTH_A4
+
+export const useTransformScale = () => {
+  const [transformScale, setTransformScale] = useState<number>(
+    calculateTransformScale(window.innerWidth),
+  )
+
+  const handleResize = useCallback(() => {
+    setTransformScale(calculateTransformScale(window.innerWidth))
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [handleResize])
+
+  return transformScale
+}

--- a/frontend/src/layouts/PublicLayout/PublicLayout.tsx
+++ b/frontend/src/layouts/PublicLayout/PublicLayout.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, Image, Stack, VStack } from '@chakra-ui/react'
+import { Flex, Heading, Image, Stack, VStack } from '@chakra-ui/react'
 import { Link as RouterLink, Outlet } from 'react-router-dom'
 
 import { AppFooter } from '~/app/AppFooter'
@@ -26,10 +26,7 @@ export const PublicLayout = () => {
           </Stack>
         </RouterLink>
       </Flex>
-
-      <Box w="full" bg="gray.100">
-        <Outlet />
-      </Box>
+      <Outlet />
       <AppFooter />
     </VStack>
   )


### PR DESCRIPTION
## Context
Responsive letters behave poorly on small screensizes as we are unable to control how page breaks and html formatting (e.g. tables, boxes) resize on small screens.

To resolve this, we make our letters non-responsive and retain the A4 fixed ratio, so that all letters to look identical on all screensizes. 

## Approach

- Adds a `useTransformScale` hook to detect screen size and resize `LetterViewer` when rendering `LetterPublicPage`. On screensizes smaller than A4, letters are rendered at 90% of screen width. On screensizes larger than A4, letters are rendered at A4 size
- For previews of letters in Drawers, letters are rendered at 90% of `DRAWER_WIDTH_IN_PIXELS`. Note that `DRAWER_WIDTH_IN_PIXELS` was hardcoded as it was difficult to extract the width of the parent component in React, and I didn't think it was worth additional engineering effort to fix as the revamped designs in Figma all do not seem to include previews in Drawers. 

## Before & After Screenshots

**BEFORE**:
![Screen Recording 2023-07-11 at 5 20 40 PM](https://github.com/opengovsg/letters/assets/39231249/c2fced1c-acfa-44d9-801a-97afd5289a73)

**AFTER**:
![Screen Recording 2023-07-11 at 5 20 09 PM](https://github.com/opengovsg/letters/assets/39231249/784c5360-5753-49bb-a5bb-36d966b945a6)

Letters that contain multiple pages
![Screen Recording 2023-07-11 at 3 40 31 PM](https://github.com/opengovsg/letters/assets/39231249/28dfbf1f-ba31-433c-81f9-ced2ffe4a976)

![Screen Recording 2023-07-11 at 4 51 50 PM](https://github.com/opengovsg/letters/assets/39231249/d3555c00-a99a-43cf-9e21-34da8c6b3014)

## Bugs
![Screen Recording 2023-07-11 at 4 53 52 PM](https://github.com/opengovsg/letters/assets/39231249/3d3770b1-2322-4cc7-b109-17794b96c7bd)
Note that on small screen sizes, there's an awkward gap between the end of the letter and the start of the footer. That's because we're only scaling the letter, not the entire page, and the scaling is done on via CSS transform (non-responsively). This means the page is unable to detect that the letter height has changed, so the footer stays the same distance away from the top of the page as if it was viewed on normal screen. There does not seem to be an easy way to resolve this for now unless we know a fixed height for the Letter, (then we could just scale the box height to be `(LetterViewer.height + padding)* transformScale`. For now, it seems like a small issue as users do not have any other functionality to click on below this gap.

Edit: ^ This is fixed for the public view
